### PR TITLE
Add semantic versioning and GoReleaser release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,39 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - main: ./cmd/sendit
+    binary: sendit
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.buildDate={{.Date}}
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - Merge pull request
+      - Merge branch

--- a/cmd/sendit/main.go
+++ b/cmd/sendit/main.go
@@ -18,6 +18,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Set by goreleaser via -ldflags at build time; fallback to "dev" for local builds.
+var (
+	version   = "dev"
+	commit    = "none"
+	buildDate = "unknown"
+)
+
 var rootCmd = &cobra.Command{
 	Use:   "sendit",
 	Short: "Realistic web traffic generator",
@@ -42,6 +49,19 @@ func init() {
 	rootCmd.AddCommand(stopCmd())
 	rootCmd.AddCommand(statusCmd())
 	rootCmd.AddCommand(validateCmd())
+	rootCmd.AddCommand(versionCmd())
+}
+
+// --- version ---
+
+func versionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print version information",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("sendit %s (commit: %s, built: %s)\n", version, commit, buildDate)
+		},
+	}
 }
 
 // --- start ---


### PR DESCRIPTION
## Summary

- Adds `version`/`commit`/`buildDate` vars to `cmd/sendit/main.go`, injected via `-ldflags` at build time (fallback to `dev`/`none`/`unknown` for local builds)
- Adds `sendit version` subcommand: `sendit v0.1.0 (commit: abc1234, built: 2026-02-28T...)`
- Adds `.goreleaser.yaml`: cross-compiles `linux+darwin` × `amd64/arm64`, produces `.tar.gz` archives + `checksums.txt`, filters changelog noise entries
- Adds `.github/workflows/release.yml`: triggers on `v*` tags, runs GoReleaser with `GITHUB_TOKEN` to publish the GitHub Release automatically

## To cut a release

```sh
git tag v0.1.0
git push origin v0.1.0
```

The workflow fires, GoReleaser builds all four platform binaries, and a GitHub Release is created with archives, checksums, and a changelog.

## Test plan

- [x] `sendit version` with ldflags prints `sendit v0.1.0 (commit: 4b7159f, built: ...)`
- [x] `sendit version` without ldflags prints `sendit dev (commit: none, built: unknown)`
- [x] `go test -race ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)