### PR TITLE
Add result export to file (v0.2.0)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,7 +16,7 @@ Features planned for future releases of sendit. Contributions are welcome — op
 
 ---
 
-## v0.2.0 — Result export
+## v0.2.0 — Result export ✓
 
 Write request results to a file for offline analysis, complementing the Prometheus scrape endpoint.
 

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -89,6 +89,13 @@ targets:
       resolver: "8.8.8.8:53"
       record_type: A
 
+# Optional: write request results to a file for offline analysis.
+# output:
+#   enabled: true
+#   file: "sendit-results.jsonl"  # path to output file
+#   format: jsonl                  # jsonl | csv
+#   append: false                  # true = append to existing file
+
 metrics:
   enabled: false
   prometheus_port: 9090

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,6 +60,11 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("backoff.multiplier", 2.0)
 	v.SetDefault("backoff.max_attempts", 3)
 
+	v.SetDefault("output.enabled", false)
+	v.SetDefault("output.file", "sendit-results.jsonl")
+	v.SetDefault("output.format", "jsonl")
+	v.SetDefault("output.append", false)
+
 	v.SetDefault("metrics.enabled", false)
 	v.SetDefault("metrics.prometheus_port", 9090)
 
@@ -221,6 +226,16 @@ func validate(cfg *Config) error {
 		}
 		if !validTypes[t.Type] {
 			errs = append(errs, fmt.Sprintf("targets[%d].type must be one of http|browser|dns|websocket, got %q", i, t.Type))
+		}
+	}
+
+	if cfg.Output.Enabled {
+		if cfg.Output.File == "" {
+			errs = append(errs, "output.file must not be empty when output.enabled is true")
+		}
+		validFormats := map[string]bool{"jsonl": true, "csv": true}
+		if !validFormats[cfg.Output.Format] {
+			errs = append(errs, fmt.Sprintf("output.format must be jsonl|csv, got %q", cfg.Output.Format))
 		}
 	}
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -9,6 +9,7 @@ type Config struct {
 	Targets        []TargetConfig       `mapstructure:"targets"`
 	TargetsFile    string               `mapstructure:"targets_file"`
 	TargetDefaults TargetDefaultsConfig `mapstructure:"target_defaults"`
+	Output         OutputConfig         `mapstructure:"output"`
 	Metrics        MetricsConfig        `mapstructure:"metrics"`
 	Daemon         DaemonConfig         `mapstructure:"daemon"`
 }
@@ -106,6 +107,14 @@ type WebSocketConfig struct {
 	DurationS      int      `mapstructure:"duration_s"`
 	SendMessages   []string `mapstructure:"send_messages"`
 	ExpectMessages int      `mapstructure:"expect_messages"`
+}
+
+// OutputConfig controls writing request results to a file.
+type OutputConfig struct {
+	Enabled bool   `mapstructure:"enabled"`
+	File    string `mapstructure:"file"`
+	Format  string `mapstructure:"format"` // jsonl | csv
+	Append  bool   `mapstructure:"append"`
 }
 
 // MetricsConfig controls Prometheus metrics exposition.

--- a/internal/output/writer.go
+++ b/internal/output/writer.go
@@ -1,0 +1,140 @@
+package output
+
+import (
+	"bufio"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/lewta/sendit/internal/config"
+	"github.com/lewta/sendit/internal/task"
+	"github.com/rs/zerolog/log"
+)
+
+const chanBuf = 512
+
+// Writer serialises task.Result values to a file in JSONL or CSV format.
+// Send is non-blocking; results are dropped (with a warning) if the internal
+// buffer is full. Close drains the buffer and flushes the file.
+type Writer struct {
+	ch   chan task.Result
+	done chan struct{}
+}
+
+// New opens the output file and starts the background writer goroutine.
+// The caller must call Close() when done.
+func New(cfg config.OutputConfig) (*Writer, error) {
+	flag := os.O_CREATE | os.O_WRONLY
+	if cfg.Append {
+		flag |= os.O_APPEND
+	} else {
+		flag |= os.O_TRUNC
+	}
+
+	f, err := os.OpenFile(cfg.File, flag, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("opening output file %q: %w", cfg.File, err)
+	}
+
+	w := &Writer{
+		ch:   make(chan task.Result, chanBuf),
+		done: make(chan struct{}),
+	}
+	go w.run(f, cfg.Format, cfg.Append)
+	return w, nil
+}
+
+// Send enqueues a result for writing. Non-blocking; drops if buffer is full.
+func (w *Writer) Send(r task.Result) {
+	select {
+	case w.ch <- r:
+	default:
+		log.Warn().Msg("output writer buffer full, dropping result")
+	}
+}
+
+// Close drains the channel and closes the file.
+func (w *Writer) Close() {
+	close(w.ch)
+	<-w.done
+}
+
+func (w *Writer) run(f *os.File, format string, appendMode bool) {
+	defer close(w.done)
+	bw := bufio.NewWriter(f)
+	defer func() {
+		_ = bw.Flush()
+		_ = f.Close()
+	}()
+
+	switch format {
+	case "csv":
+		w.runCSV(bw, appendMode)
+	default: // jsonl
+		w.runJSONL(bw)
+	}
+}
+
+type record struct {
+	TS         string `json:"ts"`
+	URL        string `json:"url"`
+	Type       string `json:"type"`
+	Status     int    `json:"status"`
+	DurationMs int64  `json:"duration_ms"`
+	Bytes      int64  `json:"bytes"`
+	Error      string `json:"error,omitempty"`
+}
+
+func toRecord(r task.Result) record {
+	errStr := ""
+	if r.Error != nil {
+		errStr = r.Error.Error()
+	}
+	return record{
+		TS:         time.Now().UTC().Format(time.RFC3339),
+		URL:        r.Task.URL,
+		Type:       r.Task.Type,
+		Status:     r.StatusCode,
+		DurationMs: r.Duration.Milliseconds(),
+		Bytes:      r.BytesRead,
+		Error:      errStr,
+	}
+}
+
+func (w *Writer) runJSONL(bw *bufio.Writer) {
+	enc := json.NewEncoder(bw)
+	for r := range w.ch {
+		if err := enc.Encode(toRecord(r)); err != nil {
+			log.Warn().Err(err).Msg("output writer: failed to encode result")
+			continue
+		}
+		_ = bw.Flush()
+	}
+}
+
+func (w *Writer) runCSV(bw *bufio.Writer, appendMode bool) {
+	cw := csv.NewWriter(bw)
+	if !appendMode {
+		_ = cw.Write([]string{"ts", "url", "type", "status", "duration_ms", "bytes", "error"})
+		cw.Flush()
+	}
+	for r := range w.ch {
+		rec := toRecord(r)
+		row := []string{
+			rec.TS,
+			rec.URL,
+			rec.Type,
+			fmt.Sprintf("%d", rec.Status),
+			fmt.Sprintf("%d", rec.DurationMs),
+			fmt.Sprintf("%d", rec.Bytes),
+			rec.Error,
+		}
+		if err := cw.Write(row); err != nil {
+			log.Warn().Err(err).Msg("output writer: failed to write CSV row")
+			continue
+		}
+		cw.Flush()
+	}
+}


### PR DESCRIPTION
## Summary

- New `internal/output` package: `Writer` serialises `task.Result` values to JSONL or CSV via a buffered channel goroutine
- `Send()` is non-blocking — results are dropped with a warn log if the 512-entry buffer fills up
- `Close()` drains the channel, flushes, and closes the file — called via `defer` in `Engine.Run()`
- New `output` config section with `enabled`, `file`, `format`, `append` fields
- Validated: unknown format or empty file path with `enabled: true` are rejected at config load time
- Commented-out example added to `config/example.yaml`

## Output formats

**JSONL** (one JSON object per line):
```json
{"ts":"2026-02-28T15:00:00Z","url":"https://httpbin.org/get","type":"http","status":200,"duration_ms":142,"bytes":1234}
```

**CSV**:
```
ts,url,type,status,duration_ms,bytes,error
2026-02-28T15:00:00Z,https://httpbin.org/get,http,200,142,1234,
```
CSV header is written only when `append: false`.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race ./...` all pass
- [x] `go vet ./...` clean
- [x] `sendit validate` accepts config with `output.enabled: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)