### PR TITLE
Add MIT license, CI workflow, and README badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test -race ./...

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 lewta
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # sendit
 
+[![CI](https://img.shields.io/github/actions/workflow/status/lewta/sendit/ci.yml?branch=main&label=tests)](https://github.com/lewta/sendit/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/lewta/sendit)](https://github.com/lewta/sendit/releases/latest)
+[![Go version](https://img.shields.io/badge/go-1.22+-00ADD8?logo=go&logoColor=white)](https://go.dev)
+[![Go Report Card](https://goreportcard.com/badge/github.com/lewta/sendit)](https://goreportcard.com/report/github.com/lewta/sendit)
+[![License](https://img.shields.io/github/license/lewta/sendit)](LICENSE)
+
 A Go CLI tool that simulates realistic user web traffic across HTTP, headless browser, DNS, and WebSocket protocols. Designed to blend into normal traffic baselines while being polite to both the local machine and target servers.
 
 Key properties:
@@ -91,6 +97,7 @@ sendit completion <shell>
 | `--config` | `-c` | `config/example.yaml` | Path to YAML config file |
 | `--foreground` | | `false` | Skip writing the PID file (process always runs in the foreground) |
 | `--log-level` | | *(from config)* | Override log level: `debug` \| `info` \| `warn` \| `error` |
+| `--dry-run` | | `false` | Print config summary (targets, pacing, limits) and exit without sending traffic |
 
 ### `stop` / `status` flags
 
@@ -279,6 +286,28 @@ targets:
       expect_messages: 1                      # wait to receive this many messages
 ```
 
+### `output`
+
+Optional result export to a file for offline analysis.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `enabled` | `false` | Enable result export |
+| `file` | `sendit-results.jsonl` | Output file path |
+| `format` | `jsonl` | `jsonl` (one JSON object per line) \| `csv` |
+| `append` | `false` | Append to an existing file instead of truncating on start |
+
+```yaml
+output:
+  enabled: true
+  file: "results.jsonl"
+  format: jsonl    # jsonl | csv
+  append: false
+```
+
+Each JSONL record contains: `ts`, `url`, `type`, `status`, `duration_ms`, `bytes`, `error`.
+CSV output writes a header row when `append: false`.
+
 ### `metrics`
 
 Optional Prometheus exposition.
@@ -338,6 +367,7 @@ internal/resource/              gopsutil CPU/RAM monitor with Admit() gate
 internal/driver/                HTTP · headless browser (chromedp) · DNS (miekg) · WebSocket
 internal/engine/                Worker pool · scheduler · dispatch loop
 internal/metrics/               Prometheus counters & histograms
+internal/output/                JSONL / CSV result writer (non-blocking, goroutine-backed)
 config/example.yaml             Full reference configuration (with target_defaults section)
 config/targets.txt              Example targets file (url + type per line)
 config/test.yaml                Lightweight HTTP+DNS config for local smoke-testing


### PR DESCRIPTION
## Summary

- **LICENSE** — MIT, copyright 2026 lewta
- **CI workflow** (`.github/workflows/ci.yml`) — runs `go vet` + `go test -race ./...` on every push and PR to `main`
- **README badges** — five badges at the top of the README:
  - Tests (CI status)
  - Latest release
  - Go version (1.22+)
  - Go Report Card
  - License (MIT)
- **README docs** — backfilled two things that shipped but weren't documented:
  - `--dry-run` flag in the `start` flags table
  - `output` config section (v0.2.0 result export)
  - `internal/output` package in the architecture tree

## Test plan

- [ ] CI workflow triggers on this PR and goes green
- [ ] LICENSE file visible on repo homepage
- [ ] Badges render correctly on README

🤖 Generated with [Claude Code](https://claude.com/claude-code)