### PR TITLE
Add sendit probe command (v0.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,19 +75,23 @@ target_defaults:
 ## CLI Commands
 
 ```
-sendit start    [-c <path>] [--foreground] [--log-level debug|info|warn|error]
+sendit start    [-c <path>] [--foreground] [--log-level debug|info|warn|error] [--dry-run]
+sendit probe    <target>   [--type http|dns] [--interval 1s] [--timeout 5s]
 sendit stop     [--pid-file <path>]
 sendit status   [--pid-file <path>]
 sendit validate [-c <path>]
+sendit version
 sendit completion <shell>
 ```
 
 | Command      | Description |
 |--------------|-------------|
 | `start`      | Start the engine. Writes a PID file by default so `stop`/`status` can find the process; use `--foreground` to skip writing the PID file. |
+| `probe`      | Test a single HTTP or DNS endpoint in a loop (like ping). No config file required. |
 | `stop`       | Send SIGTERM to a running instance via its PID file. |
 | `status`     | Check whether the process in the PID file is still alive. |
 | `validate`   | Parse and validate a config file without starting the engine. Exits 0 on success, non-zero with a message on failure. |
+| `version`    | Print version, commit, and build date. |
 | `completion` | Generate shell autocompletion scripts (bash, zsh, fish, powershell). |
 
 ### `start` flags
@@ -98,6 +102,16 @@ sendit completion <shell>
 | `--foreground` | | `false` | Skip writing the PID file (process always runs in the foreground) |
 | `--log-level` | | *(from config)* | Override log level: `debug` \| `info` \| `warn` \| `error` |
 | `--dry-run` | | `false` | Print config summary (targets, pacing, limits) and exit without sending traffic |
+
+### `probe` flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--type` | *(auto-detected)* | Driver type: `http` \| `dns` |
+| `--interval` | `1s` | Delay between requests |
+| `--timeout` | `5s` | Per-request timeout |
+| `--resolver` | `8.8.8.8:53` | DNS resolver (dns targets only) |
+| `--record-type` | `A` | DNS record type (dns targets only) |
 
 ### `stop` / `status` flags
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,33 @@ Write request results to a file for offline analysis, complementing the Promethe
 
 ---
 
-## v0.3.0 — Config hot-reload
+## v0.3.0 — Probe command ✓
+
+A `sendit probe <target>` subcommand for interactively testing a single HTTP or DNS endpoint
+in a loop — no config file needed. Works like `ping` for web targets.
+
+- Auto-detects type from URL scheme (`https://` → http, bare hostname → dns)
+- `--type`, `--interval`, `--timeout`, `--resolver`, `--record-type` flags
+- Prints one line per request with status, latency, and bytes (HTTP) or rcode (DNS)
+- Prints a summary (sent, ok, errors, min/avg/max latency) on Ctrl-C
+
+```
+$ sendit probe https://example.com
+
+Probing https://example.com (http) — Ctrl-C to stop
+
+  200   142ms  1.2 KB
+  200    38ms  1.2 KB
+^C
+
+--- https://example.com ---
+2 sent, 2 ok, 0 error(s)
+min/avg/max latency: 38ms / 90ms / 142ms
+```
+
+---
+
+## v0.4.0 — Config hot-reload
 
 Reload configuration on `SIGHUP` without restarting the process or dropping in-flight requests.
 
@@ -36,7 +62,7 @@ Reload configuration on `SIGHUP` without restarting the process or dropping in-f
 
 ---
 
-## v0.4.0 — Container support
+## v0.5.0 — Container support
 
 Package sendit as a Docker image for portability and scheduled runs in CI or on a server.
 
@@ -47,7 +73,7 @@ Package sendit as a Docker image for portability and scheduled runs in CI or on 
 
 ---
 
-## v0.5.0 — Documentation site
+## v0.6.0 — Documentation site
 
 Public reference documentation hosted on GitHub Pages.
 


### PR DESCRIPTION
Closes #5.

## Summary

New `sendit probe <target>` subcommand — tests a single HTTP or DNS endpoint in a loop with no config file required.

## Usage

```
# HTTP — auto-detected from https:// prefix
sendit probe https://example.com

# DNS — auto-detected from bare hostname
sendit probe example.com

# DNS with overrides
sendit probe example.com --record-type AAAA --resolver 1.1.1.1:53 --interval 500ms
```

## Output

**HTTP:**
```
Probing https://example.com (http) — Ctrl-C to stop

  200   142ms  1.2 KB
  200    38ms  1.2 KB
^C

--- https://example.com ---
2 sent, 2 ok, 0 error(s)
min/avg/max latency: 38ms / 90ms / 142ms
```

**DNS:**
```
Probing example.com (dns, A @ 8.8.8.8:53) — Ctrl-C to stop

  NOERROR    42ms
  NOERROR    38ms
^C

--- example.com ---
2 sent, 2 ok, 0 error(s)
min/avg/max latency: 38ms / 40ms / 42ms
```

## Implementation

- `probeCmd()` in `cmd/sendit/main.go` — uses `driver.HTTPDriver` and `driver.DNSDriver` directly (no engine, no config, no scheduler)
- Each request wrapped in `context.WithTimeout` for uniform timeout across both drivers
- First request fires immediately, then `time.Ticker` at `--interval`
- ROADMAP.md updated: probe is v0.3.0 ✓, hot-reload shifts to v0.4.0, etc.
- README: CLI commands table and `probe` flags section added

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test -race ./...` all clean
- [x] `sendit probe https://httpbin.org/get` — live HTTP output confirmed
- [x] `sendit probe example.com` — live DNS output confirmed
- [x] `sendit probe --help` — flags documented correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)