### PR TITLE
docs: add SIGHUP reload and probe to CLI help text

### DIFF
--- a/cmd/sendit/main.go
+++ b/cmd/sendit/main.go
@@ -37,6 +37,9 @@ browser, DNS, and WebSocket protocols.
 Targets are defined in a YAML config file under 'targets' (inline) and/or
 loaded from a plain-text file via 'targets_file'. Both can be used together.
 
+Use 'sendit probe <target>' to test a single endpoint interactively without
+a config file — works like ping for HTTP and DNS targets.
+
 Use 'sendit validate' to check a config before running.`,
 }
 
@@ -281,7 +284,11 @@ Default field values for file-loaded targets (method, timeout, resolver,
 etc.) are configured under 'target_defaults:' in the YAML.
 
 The engine shuts down gracefully on SIGINT or SIGTERM, waiting for all
-in-flight requests to complete before exiting.`,
+in-flight requests to complete before exiting.
+
+Send SIGHUP to reload the config without restarting. Targets, rate limits,
+backoff, and pacing are updated atomically with no dropped requests. Changes
+to pacing mode or resource limits (workers, cpu, memory) require a restart.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load(cfgPath)
 			if err != nil {


### PR DESCRIPTION
## Summary

- Root `sendit --help`: adds a mention of `sendit probe` so the interactive testing command is discoverable without browsing the subcommand list
- `sendit start --help`: adds a paragraph documenting SIGHUP hot-reload — what updates atomically and what requires a restart

## Test plan

- [ ] `go build ./cmd/sendit && ./sendit --help` — probe blurb present
- [ ] `./sendit start --help` — SIGHUP paragraph present

🤖 Generated with [Claude Code](https://claude.com/claude-code)