### PR TITLE
Revert direct commit to main (goreleaser archives.format)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,7 @@ builds:
       - -X main.buildDate={{.Date}}
 
 archives:
-  - formats: [tar.gz]
+  - format: tar.gz
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:


### PR DESCRIPTION
Reverts 7c5f845 which was pushed directly to main, bypassing the branch protection rule requiring PRs.

The fix itself will be re-applied in a follow-up PR through the correct process.