### PR TITLE
build: replace deprecated archives.format with formats list

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,7 @@ builds:
       - -X main.buildDate={{.Date}}
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:


### PR DESCRIPTION
## Summary

- Replaces the deprecated `format: tar.gz` field under `archives:` with the new `formats: [tar.gz]` list syntax required by GoReleaser v2
- Silences the deprecation warning emitted on every release build
- Config validated locally with `goreleaser check`

Fixes #9

## Test plan

- [ ] CI passes
- [ ] Next release build produces no deprecation warning for `archives.format`