### PR TITLE
ci: fix govulncheck duplicate Authorization header failure

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,6 +24,8 @@ jobs:
           cache: true
 
       - uses: golang/govulncheck-action@v1
+        with:
+          repo-checkout: false  # repo already checked out above; avoids duplicate Authorization header
 
   codeql:
     name: CodeQL


### PR DESCRIPTION
## Problem

`golang/govulncheck-action@v1` defaults to `repo-checkout: true`, which performs a second `git clone` after `actions/checkout@v6` has already run. This causes a duplicate `Authorization` header on GitHub's HTTPS git endpoint, returning HTTP 400 and killing the job before the vulnerability scan even starts.

This has been causing every govulncheck run to fail today with:
```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/lewta/sendit/': The requested URL returned error: 400
```

## Fix

Set `repo-checkout: false` on the action — it then uses the workspace already checked out by `actions/checkout@v6`.

## Test plan

- [ ] govulncheck job completes and actually runs the scan