### PR TITLE
fix: migrate WebSocket driver from nhooyr.io/websocket to coder/websocket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24
 
 require (
 	github.com/chromedp/chromedp v0.14.2
+	github.com/coder/websocket v1.8.14
 	github.com/miekg/dns v1.1.58
 	github.com/prometheus/client_golang v1.23.2
 	github.com/robfig/cron/v3 v3.0.1
@@ -12,7 +13,6 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.21.0
 	golang.org/x/time v0.5.0
-	nhooyr.io/websocket v1.8.11
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/chromedp/chromedp v0.14.2 h1:r3b/WtwM50RsBZHMUm9fsNhhzRStTHrKdr2zmwbZ
 github.com/chromedp/chromedp v0.14.2/go.mod h1:rHzAv60xDE7VNy/MYtTUrYreSc0ujt2O1/C3bzctYBo=
 github.com/chromedp/sysutil v1.1.0 h1:PUFNv5EcprjqXZD9nJb9b/c9ibAbxiYo4exNWZyipwM=
 github.com/chromedp/sysutil v1.1.0/go.mod h1:WiThHUdltqCNKGc4gaU50XgYjwjYIhKWoHGPTUfWTJ8=
+github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
+github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -147,5 +149,3 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-nhooyr.io/websocket v1.8.11 h1:f/qXNc2/3DpoSZkHt1DQu6rj4zGC8JmkkLkWss0MgN0=
-nhooyr.io/websocket v1.8.11/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=

--- a/internal/driver/websocket.go
+++ b/internal/driver/websocket.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/coder/websocket"
 	"github.com/lewta/sendit/internal/task"
-	"nhooyr.io/websocket"
 )
 
 // WebSocketDriver connects to a WebSocket endpoint, sends messages, and waits.

--- a/internal/engine/integration_test.go
+++ b/internal/engine/integration_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/lewta/sendit/internal/engine"
 	"github.com/lewta/sendit/internal/metrics"
 	"github.com/miekg/dns"
-	"nhooyr.io/websocket"
+	"github.com/coder/websocket"
 )
 
 // testCfg constructs a *config.Config suitable for fast integration tests:


### PR DESCRIPTION
## Summary

- Replaces `nhooyr.io/websocket` with `github.com/coder/websocket` in `internal/driver/websocket.go` and the integration test WebSocket server
- `nhooyr.io/websocket` v1.8.17+ deprecates its entire public API with SA1019 warnings pointing to the `coder/websocket` fork — this migration removes a deprecated, unmaintained dependency
- The public API is intentionally compatible; only the import path changes
- `go mod tidy` removes `nhooyr.io/websocket` from `go.mod` and `go.sum` entirely

## Test plan

- [ ] CI passes (lint, test, govulncheck)
- [ ] `nhooyr.io/websocket` no longer present in `go.mod` / `go.sum`

Closes #23