### PR TITLE
docs: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Report a reproducible problem
+labels: bug
+---
+
+## What happened?
+
+<!-- A clear description of the bug. -->
+
+## What did you expect to happen?
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Config (if relevant)
+
+```yaml
+# Paste your config here (remove any sensitive values)
+```
+
+## Environment
+
+- sendit version: <!-- run `sendit version` -->
+- OS:
+- Go version (if built from source):

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Propose a new feature or improvement
+labels: enhancement
+---
+
+## What problem does this solve?
+
+<!-- Describe the use case or pain point. -->
+
+## Proposed solution
+
+<!-- Describe what you'd like to see added or changed. -->
+
+## Alternatives considered
+
+<!-- Any other approaches you thought of? -->


### PR DESCRIPTION
## Summary

- Adds `.github/ISSUE_TEMPLATE/bug_report.md` — prompts for description, reproduction steps, config snippet, and environment details
- Adds `.github/ISSUE_TEMPLATE/feature_request.md` — prompts for problem statement, proposed solution, and alternatives considered

🤖 Generated with [Claude Code](https://claude.com/claude-code)