### PR TITLE
docs: add reload command to README and fix WebSocket ref in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Backoff and per-domain rate-limit waits happen **inside** the goroutine so a slo
 | `internal/config` | Viper-backed YAML loader. `schema.go` defines all struct types. Validates on load; `targets_file` is parsed here too. |
 | `internal/task` | `Task`/`Result` types. `Selector` uses the Vose alias method for O(1) weighted random picks. |
 | `internal/ratelimit` | `Registry` — per-domain `x/time/rate` token buckets. `BackoffRegistry` — decorrelated jitter backoff (AWS-style); shared by all domains, keyed by hostname. `ClassifyError`/`ClassifyStatusCode` unify error handling across all driver types. |
-| `internal/driver` | `Driver` interface with four implementations: `http`, `browser` (chromedp), `dns` (miekg/dns), `websocket` (nhooyr.io). DNS RCODEs are mapped to HTTP-like status codes so the engine's error classifier works uniformly. |
+| `internal/driver` | `Driver` interface with four implementations: `http`, `browser` (chromedp), `dns` (miekg/dns), `websocket` (coder/websocket). DNS RCODEs are mapped to HTTP-like status codes so the engine's error classifier works uniformly. |
 | `internal/resource` | gopsutil CPU/RAM poller. `Admit()` blocks dispatch when either threshold is exceeded. |
 | `internal/metrics` | Prometheus counters/histograms. `Noop()` returns a no-op implementation when metrics are disabled — avoids nil checks everywhere. |
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ target_defaults:
 sendit start    [-c <path>] [--foreground] [--log-level debug|info|warn|error] [--dry-run]
 sendit probe    <target>   [--type http|dns] [--interval 1s] [--timeout 5s]
 sendit stop     [--pid-file <path>]
+sendit reload   [--pid-file <path>]
 sendit status   [--pid-file <path>]
 sendit validate [-c <path>]
 sendit version
@@ -101,6 +102,7 @@ sendit completion <shell>
 | `start`      | Start the engine. Writes a PID file by default so `stop`/`status` can find the process; use `--foreground` to skip writing the PID file. |
 | `probe`      | Test a single HTTP or DNS endpoint in a loop (like ping). No config file required. |
 | `stop`       | Send SIGTERM to a running instance via its PID file. |
+| `reload`     | Send SIGHUP to a running instance via its PID file to reload the config atomically. |
 | `status`     | Check whether the process in the PID file is still alive. |
 | `validate`   | Parse and validate a config file without starting the engine. Exits 0 on success, non-zero with a message on failure. |
 | `version`    | Print version, commit, and build date. |
@@ -125,7 +127,7 @@ sendit completion <shell>
 | `--resolver` | `8.8.8.8:53` | DNS resolver (dns targets only) |
 | `--record-type` | `A` | DNS record type (dns targets only) |
 
-### `stop` / `status` flags
+### `stop` / `reload` / `status` flags
 
 | Flag | Default | Description |
 |------|---------|-------------|


### PR DESCRIPTION
## Summary

- Adds `sendit reload [--pid-file <path>]` to the command synopsis, command table, and flags section in README.md
- Updates the `stop` / `status` flags section heading to `stop` / `reload` / `status`
- Fixes stale `nhooyr.io` → `coder/websocket` reference in CLAUDE.md driver table

Closes #36, closes #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)