### PR TITLE
test: add CLI command tests and Engine.Reload() unit tests

### DIFF
--- a/cmd/sendit/main_test.go
+++ b/cmd/sendit/main_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// writePIDFile writes pid to a temp file and returns the path.
+func writePIDFile(t *testing.T, pid int) string {
+	t.Helper()
+	f := filepath.Join(t.TempDir(), "sendit.pid")
+	if err := os.WriteFile(f, []byte(fmt.Sprintf("%d", pid)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+// --- stopCmd ---
+
+func TestStopCmd_MissingPIDFile(t *testing.T) {
+	cmd := stopCmd()
+	cmd.SetArgs([]string{"--pid-file", "/tmp/sendit-no-such-file.pid"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing PID file, got nil")
+	}
+}
+
+func TestStopCmd_InvalidPIDFile(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "bad.pid")
+	if err := os.WriteFile(f, []byte("not-a-number"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := stopCmd()
+	cmd.SetArgs([]string{"--pid-file", f})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error for invalid PID, got nil")
+	}
+}
+
+func TestStopCmd_SendsSIGTERM(t *testing.T) {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGTERM)
+	defer signal.Stop(ch)
+
+	pid := os.Getpid()
+	cmd := stopCmd()
+	cmd.SetArgs([]string{"--pid-file", writePIDFile(t, pid)})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("stopCmd returned error: %v", err)
+	}
+
+	select {
+	case sig := <-ch:
+		if sig != syscall.SIGTERM {
+			t.Errorf("got signal %v, want SIGTERM", sig)
+		}
+	case <-time.After(time.Second):
+		t.Error("SIGTERM not received within 1s")
+	}
+}
+
+// --- reloadCmd ---
+
+func TestReloadCmd_MissingPIDFile(t *testing.T) {
+	cmd := reloadCmd()
+	cmd.SetArgs([]string{"--pid-file", "/tmp/sendit-no-such-file.pid"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error for missing PID file, got nil")
+	}
+}
+
+func TestReloadCmd_InvalidPIDFile(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "bad.pid")
+	if err := os.WriteFile(f, []byte("not-a-number"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := reloadCmd()
+	cmd.SetArgs([]string{"--pid-file", f})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error for invalid PID, got nil")
+	}
+}
+
+func TestReloadCmd_SendsSIGHUP(t *testing.T) {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGHUP)
+	defer signal.Stop(ch)
+
+	pid := os.Getpid()
+	var out bytes.Buffer
+	cmd := reloadCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--pid-file", writePIDFile(t, pid)})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("reloadCmd returned error: %v", err)
+	}
+
+	select {
+	case sig := <-ch:
+		if sig != syscall.SIGHUP {
+			t.Errorf("got signal %v, want SIGHUP", sig)
+		}
+	case <-time.After(time.Second):
+		t.Error("SIGHUP not received within 1s")
+	}
+
+	want := fmt.Sprintf("Sent reload signal to pid %d\n", pid)
+	if got := out.String(); got != want {
+		t.Errorf("output = %q, want %q", got, want)
+	}
+}
+
+// --- statusCmd ---
+
+func TestStatusCmd_MissingPIDFile(t *testing.T) {
+	// statusCmd treats a missing PID file as "not running" — no error returned.
+	cmd := statusCmd()
+	cmd.SetArgs([]string{"--pid-file", "/tmp/sendit-no-such-file.pid"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("statusCmd returned unexpected error: %v", err)
+	}
+}
+
+func TestStatusCmd_RunningProcess(t *testing.T) {
+	pid := os.Getpid()
+	cmd := statusCmd()
+	cmd.SetArgs([]string{"--pid-file", writePIDFile(t, pid)})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("statusCmd returned error for live process: %v", err)
+	}
+}
+
+func TestStatusCmd_DeadProcess(t *testing.T) {
+	// PID 0 is never a valid user process; Signal(0) on it returns an error,
+	// which statusCmd treats as "not running" without returning an error itself.
+	cmd := statusCmd()
+	cmd.SetArgs([]string{"--pid-file", writePIDFile(t, 99999999)})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("statusCmd returned unexpected error for dead process: %v", err)
+	}
+}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1,6 +1,134 @@
 package engine
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/lewta/sendit/internal/config"
+	"github.com/lewta/sendit/internal/metrics"
+)
+
+func baseCfg(targets []config.TargetConfig) *config.Config {
+	return &config.Config{
+		Pacing: config.PacingConfig{
+			Mode:              "rate_limited",
+			RequestsPerMinute: 60,
+		},
+		Limits: config.LimitsConfig{
+			MaxWorkers:        2,
+			MaxBrowserWorkers: 1,
+			CPUThresholdPct:   100,
+			MemoryThresholdMB: 999999,
+		},
+		RateLimits: config.RateLimitsConfig{DefaultRPS: 10},
+		Backoff: config.BackoffConfig{
+			InitialMs:   100,
+			MaxMs:       1000,
+			Multiplier:  2.0,
+			MaxAttempts: 3,
+		},
+		Targets: targets,
+	}
+}
+
+func TestReload_SwapsTargets(t *testing.T) {
+	initial := []config.TargetConfig{
+		{URL: "https://a.example.com", Weight: 1, Type: "http"},
+	}
+	eng, err := New(baseCfg(initial), metrics.Noop())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	updated := []config.TargetConfig{
+		{URL: "https://b.example.com", Weight: 1, Type: "http"},
+	}
+	newCfg := baseCfg(updated)
+	if err := eng.Reload(newCfg); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	// After reload the stored config must reflect the new targets.
+	got := eng.cfg.Load().Targets
+	if len(got) != 1 || got[0].URL != "https://b.example.com" {
+		t.Errorf("cfg.Targets after reload = %v, want b.example.com", got)
+	}
+
+	// The selector must serve tasks from the new target list.
+	for range 20 {
+		task := eng.selector.Load().Pick()
+		if task.URL != "https://b.example.com" {
+			t.Errorf("selector returned %q after reload, want b.example.com", task.URL)
+		}
+	}
+}
+
+func TestReload_SwapsRateLimits(t *testing.T) {
+	targets := []config.TargetConfig{
+		{URL: "https://a.example.com", Weight: 1, Type: "http"},
+	}
+	eng, err := New(baseCfg(targets), metrics.Noop())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	newCfg := baseCfg(targets)
+	newCfg.RateLimits = config.RateLimitsConfig{
+		DefaultRPS: 99,
+		PerDomain:  []config.DomainRateLimit{{Domain: "a.example.com", RPS: 42}},
+	}
+	if err := eng.Reload(newCfg); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	if got := eng.cfg.Load().RateLimits.DefaultRPS; got != 99 {
+		t.Errorf("DefaultRPS after reload = %v, want 99", got)
+	}
+}
+
+func TestReload_SwapsBackoff(t *testing.T) {
+	targets := []config.TargetConfig{
+		{URL: "https://a.example.com", Weight: 1, Type: "http"},
+	}
+	eng, err := New(baseCfg(targets), metrics.Noop())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	newCfg := baseCfg(targets)
+	newCfg.Backoff = config.BackoffConfig{
+		InitialMs:   200,
+		MaxMs:       5000,
+		Multiplier:  3.0,
+		MaxAttempts: 5,
+	}
+	if err := eng.Reload(newCfg); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	bo := eng.backoff.Load()
+	if got := bo.MaxAttempts(); got != 5 {
+		t.Errorf("backoff MaxAttempts after reload = %d, want 5", got)
+	}
+}
+
+func TestReload_PacingModeChangeNoError(t *testing.T) {
+	targets := []config.TargetConfig{
+		{URL: "https://a.example.com", Weight: 1, Type: "http"},
+	}
+	eng, err := New(baseCfg(targets), metrics.Noop())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Changing pacing mode should log a warning but not return an error.
+	newCfg := baseCfg(targets)
+	newCfg.Pacing.Mode = "human"
+	newCfg.Pacing.MinDelayMs = 100
+	newCfg.Pacing.MaxDelayMs = 500
+	if err := eng.Reload(newCfg); err != nil {
+		t.Fatalf("Reload with mode change returned error: %v", err)
+	}
+}
 
 func TestHostname(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

- Adds `cmd/sendit/main_test.go` with tests for `stopCmd`, `reloadCmd`, and `statusCmd` — covering missing PID file, invalid PID, signal delivery to self, and process liveness detection
- Adds four `TestReload_*` cases to `internal/engine/engine_test.go` covering target swap, rate-limit swap, backoff swap, and pacing mode change warning

Closes #38, closes #39.

## Test plan

- [x] `go test -race ./...` passes
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)