### PR TITLE
ci(docs): add PR build check and hugo mod verify

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,10 +4,13 @@ on:
   push:
     branches: [main]
     paths: ["docs/**"]
+  pull_request:
+    branches: [main]
+    paths: ["docs/**"]
   workflow_dispatch:
 
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -16,11 +19,8 @@ permissions:
   id-token: write
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -36,15 +36,29 @@ jobs:
           hugo-version: "0.147.1"
           extended: true
 
+      - name: Verify Hugo modules
+        run: hugo mod verify
+        working-directory: docs
+
       - name: Build
         run: hugo --minify --baseURL "https://lewta.github.io/sendit/"
         working-directory: docs
 
-      - uses: actions/configure-pages@v5
-
-      - uses: actions/upload-pages-artifact@v3
+      - name: Upload Pages artifact
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
         with:
           path: docs/public
+
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/configure-pages@v5
 
       - id: deploy
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Problem

The docs workflow only triggered on push to `main`, so a broken Hugo build wasn't caught until after merge. There was also no check that `docs/go.sum` was consistent with `docs/go.mod`.

## Changes

**Split `deploy` job into `build` + `deploy`:**
- `build` — runs on every PR and push to `main` touching `docs/**`; catches broken builds before they land
- `deploy` — runs only on push to `main`, gated on `build` succeeding

**Add `hugo mod verify`:**
- Runs inside `docs/` before the build step
- Fails fast if `go.sum` doesn't match the declared modules (e.g. someone edited `go.mod` without running `hugo mod tidy`)

**Concurrency group scoped to `${{ github.ref }}`:**
- Previously all runs shared the `pages` group, so a PR build could cancel a main deploy (or vice versa)

## Test plan

- [ ] Open a docs PR → `build` job runs, `deploy` job is skipped
- [ ] Merge to main → `build` runs then `deploy` runs, site updates
- [ ] Intentionally corrupt `docs/go.sum` → `hugo mod verify` fails the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)