### PR TITLE
docs: split v0.9.0 into probe WebSocket (v0.9.0) and distribution (v0.10.0)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -113,11 +113,18 @@ Better visibility into per-target behaviour from Prometheus metrics.
 
 ---
 
-## v0.9.0 — Probe WebSocket + distribution
+## v0.9.0 — Probe WebSocket
 
-Complete driver coverage in the probe tool and make sendit easy to install.
+Complete driver coverage in the probe tool.
 
-- **Probe WebSocket** — extend `sendit probe` to support `wss://` targets; connects, optionally sends a message, waits for a reply, and prints latency per round-trip
+- Extend `sendit probe` to support `wss://` targets; connects, optionally sends a message, waits for a reply, and prints latency per round-trip
+
+---
+
+## v0.10.0 — Distribution
+
+Make sendit easy to install without building from source.
+
 - **Homebrew tap** — `brew install lewta/tap/sendit` as a distribution channel; tap repo auto-updated by GoReleaser on each release
 
 ---


### PR DESCRIPTION
## Summary

- Splits the former v0.9.0 "Probe WebSocket + distribution" into two focused releases:
  - **v0.9.0** — Probe WebSocket only
  - **v0.10.0** — Homebrew tap / distribution
- v1.0.0 is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)