### PR TITLE
docs: add v0.11.0 config generator roadmap item

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -155,6 +155,13 @@ sendit generate --targets-file config/targets.txt > config/generated.yaml
 sendit generate --url https://example.com --crawl --depth 2 --output config/generated.yaml
 ```
 
+**Documentation deliverables** (required as part of the same release):
+
+- **CLI help** — `Use`, `Short`, and `Long` descriptions on the `generate` command and all flags, consistent with the style of `probe` and `pinch`
+- **`README.md`** — add `sendit generate` to the CLI commands usage block and command table; add a Generate section with both usage modes and example output, alongside the existing Probe and Pinch sections
+- **`docs/content/docs/cli.md`** — add `generate` to the commands block and table; add a `generate` flags section with both modes, flag reference, and annotated example output
+- **`docs/content/docs/getting-started.md`** — add a "Generate a config from a URL" subsection under the quick-start flow so new users discover the crawl mode as the fastest path to a working config
+
 ---
 
 ## v1.0.0 — TUI + stable API


### PR DESCRIPTION
## Summary

Adds **v0.11.0 — Config generator** to the roadmap, slotting between v0.10.0 (Distribution) and v1.0.0 (TUI).

### Feature overview

`sendit generate` produces a ready-to-use `config.yaml` from:

- **A targets file** — parses an existing `targets_file` and emits a full config with sensible defaults
- **A seed URL + `--crawl`** — discovers in-domain HTTP links up to a configurable depth/page limit and adds each as a weighted target; respects `robots.txt` by default

### Flags planned
`--targets-file`, `--url`, `--crawl`, `--depth`, `--max-pages`, `--ignore-robots`, `--output`

🤖 Generated with [Claude Code](https://claude.com/claude-code)