### PR TITLE
docs: surface probe and pinch as key features on docs homepage

### DIFF
--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -6,6 +6,24 @@ description: "Reference documentation for sendit — a flexible traffic generato
 
 Welcome to the sendit reference documentation.
 
+## Quick tools — no config required
+
+Two commands let you verify connectivity instantly without writing a config file:
+
+| Command | What it does |
+|---|---|
+| [`sendit probe <target>`](cli/#probe-flags) | Test a single HTTP or DNS endpoint in a loop. Auto-detects the driver from the URL. Works like `ping` for web targets. |
+| [`sendit pinch <host:port>`](cli/#pinch-flags) | Check whether a TCP or UDP port is open on a remote host, repeating on an interval. |
+
+```sh
+sendit probe https://example.com       # HTTP — prints status, latency, bytes per request
+sendit probe example.com               # DNS  — prints RCODE and latency per query
+sendit pinch example.com:443           # TCP  — prints open/closed/filtered per check
+sendit pinch 8.8.8.8:53 --type udp    # UDP  — prints open/closed/open|filtered per check
+```
+
+Press Ctrl-C to stop and print a summary. See the [CLI Reference](cli/) for all flags.
+
 ## Sections
 
 | Section | What you'll find |

--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -50,6 +50,8 @@ Probing https://example.com (http) — Ctrl-C to stop
 min/avg/max latency: 38ms / 90ms / 142ms
 ```
 
+See the [CLI Reference](../cli/#probe-flags) for all `probe` flags.
+
 `sendit pinch` checks TCP/UDP port connectivity in the same style — useful for verifying a service is reachable before running traffic against it:
 
 ```sh
@@ -71,6 +73,8 @@ Pinching example.com:80 (tcp) — Ctrl-C to stop
 2 sent, 2 open, 0 closed/filtered
 min/avg/max latency: 38ms / 90ms / 142ms
 ```
+
+See the [CLI Reference](../cli/#pinch-flags) for all `pinch` flags.
 
 ## Create a config file
 


### PR DESCRIPTION
Closes #51

## Changes

**`docs/content/docs/_index.md`**
- Adds a "Quick tools — no config required" section at the top with a summary table and a four-line code example covering all four modes (HTTP probe, DNS probe, TCP pinch, UDP pinch)
- Links through to the CLI Reference

**`docs/content/docs/getting-started.md`**
- Adds a `[CLI Reference](../cli/#probe-flags)` link after the probe example
- Adds a `[CLI Reference](../cli/#pinch-flags)` link after the pinch example

**Issue #40** — closed separately: all four `TestReload_*` cases were already present in `engine_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)