### PR TITLE
ci: add integration test job to run on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,16 @@ jobs:
 
       - name: Test
         run: go test -race ./...
+
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Integration tests
+        run: go test -race -tags integration -v ./internal/engine/...


### PR DESCRIPTION
Closes #58

## Summary

Adds a dedicated `integration` job to `ci.yml` that runs in parallel with `lint` and `test`:

```
go test -race -tags integration -v ./internal/engine/...
```

- Separate job so a failure shows up as **"integration"** in the PR checks list, not silently skipped
- `-v` so individual test names are visible in the Actions log
- `-race` consistent with the unit test job
- Triggers on the same events as the other jobs (push to `main`, all PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)