### PR TITLE
test: add unit tests for internal/output and internal/driver

### DIFF
--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -157,8 +157,8 @@ func startDNSServer(t *testing.T, handler func(w dns.ResponseWriter, r *dns.Msg)
 	mux := dns.NewServeMux()
 	mux.HandleFunc(".", handler)
 	srv := &dns.Server{PacketConn: pc, Net: "udp", Handler: mux}
-	go srv.ActivateAndServe()            //nolint:errcheck
-	t.Cleanup(func() { srv.Shutdown() }) //nolint:errcheck
+	go srv.ActivateAndServe() //nolint:errcheck
+	t.Cleanup(func() { _ = srv.Shutdown() })
 	return addr
 }
 

--- a/internal/output/writer_test.go
+++ b/internal/output/writer_test.go
@@ -74,7 +74,7 @@ func TestWriter_JSONL_ErrorField(t *testing.T) {
 
 	data, _ := os.ReadFile(f)
 	var rec record
-	json.Unmarshal([]byte(strings.TrimRight(string(data), "\n")), &rec) //nolint:errcheck
+	_ = json.Unmarshal([]byte(strings.TrimRight(string(data), "\n")), &rec)
 
 	if !strings.Contains(rec.Error, "connection refused") {
 		t.Errorf("Error = %q, want to contain 'connection refused'", rec.Error)


### PR DESCRIPTION
Closes #56
Closes #57

## Summary

Eliminates the two `[no test files]` packages from `go test ./...` output.

### `internal/output/writer_test.go` (6 tests)

| Test | What it verifies |
|---|---|
| `TestWriter_JSONL` | All JSONL fields map correctly (url, type, status, duration_ms, bytes) |
| `TestWriter_JSONL_ErrorField` | Non-nil error is serialised into the `error` field |
| `TestWriter_CSV` | Header row written + data columns map correctly |
| `TestWriter_CSV_AppendNoHeader` | Append mode writes no second header; both records present |
| `TestWriter_Truncate` | Append:false overwrites prior file content |
| `TestWriter_CloseDrainsBuffer` | All 20 buffered results are flushed before Close returns |

### `internal/driver/driver_test.go` (13 tests, 1 skip)

| Test | What it verifies |
|---|---|
| `TestHTTPDriver_200` | Status, BytesRead, Duration on a 200 response |
| `TestHTTPDriver_4xx` | 404 status code passed through, no error |
| `TestHTTPDriver_Timeout` | Driver-level timeout (TimeoutS:1) returns error |
| `TestHTTPDriver_CustomHeaders` | Request headers reach the server |
| `TestHTTPDriver_POST_WithBody` | Body is sent on POST requests |
| `TestDNSDriver_NOERROR` | NOERROR → StatusCode 200 |
| `TestDNSDriver_NXDOMAIN` | NXDOMAIN → StatusCode 404 |
| `TestDNSDriver_SERVFAIL` | SERVFAIL → StatusCode 503 |
| `TestDNSDriver_UnreachableResolver` | Unreachable resolver returns error |
| `TestWebSocketDriver_Connect` | Successful connect → StatusCode 101 |
| `TestWebSocketDriver_ServerClosesEarly` | Driver doesn't hang when server closes first |
| `TestBrowserDriver_Skipped` | Documents Chrome requirement; skipped in CI |

🤖 Generated with [Claude Code](https://claude.com/claude-code)