### PR TITLE
chore: ignore Hugo root-level build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,13 @@
 # Claude Code local settings
 .claude/
 
-# Hugo docs build output
+# Hugo docs build output (docs/ subdirectory)
 docs/public/
 docs/resources/
+
+# Hugo build artifacts if run from repo root
+.hugo_build.lock
+public/
 
 # Editor
 .idea/


### PR DESCRIPTION
## Summary

`.hugo_build.lock` and `public/` are generated when `hugo` is run from the repo root rather than from `docs/`. The `docs/` equivalents were already in `.gitignore`; this adds the root-level paths to keep `git status` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)