### PR TITLE
feat(docker): container support (v0.7.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,64 @@ min/avg/max latency: 4ms / 4ms / 4ms
 
 ---
 
+## Docker
+
+The `docker/` directory contains a ready-to-use Docker setup. The image is built from source so no binary download is needed.
+
+### Quick start
+
+```sh
+# 1. Copy and edit the example config
+cp docker/config.yaml docker/my-config.yaml
+
+# 2. Build and run (config is mounted as a volume)
+cd docker
+docker compose up --build
+```
+
+Prometheus metrics are exposed on port **9090**. A liveness probe is available at `GET /healthz` on the same port.
+
+### With Prometheus + Grafana
+
+```sh
+cd docker
+docker compose --profile observability up --build
+```
+
+This starts three containers:
+
+| Service | Port | Description |
+|---------|------|-------------|
+| `sendit` | 9090 | Main process + `/metrics` + `/healthz` |
+| `prometheus` | 9091 | Scrapes sendit every 15 s |
+| `grafana` | 3000 | Dashboard UI (anonymous access pre-enabled) |
+
+### Config
+
+Mount your config at `/etc/sendit/config.yaml`. For container deployments, set:
+
+```yaml
+metrics:
+  enabled: true
+  prometheus_port: 9090
+
+daemon:
+  log_format: json   # friendlier for log aggregators
+```
+
+The `--foreground` flag is set in the image entrypoint — PID files are not useful inside containers.
+
+### Files
+
+| File | Description |
+|------|-------------|
+| `docker/Dockerfile` | Multi-stage build (`golang:1.24-alpine` → `alpine`) |
+| `docker/docker-compose.yml` | sendit + optional Prometheus/Grafana via `--profile observability` |
+| `docker/config.yaml` | Docker-ready example config (metrics enabled, JSON logs) |
+| `docker/prometheus.yml` | Prometheus scrape config targeting `sendit:9090` |
+
+---
+
 ## Configuration Reference
 
 See [`config/example.yaml`](config/example.yaml) for a full working example. Every section has defaults so you only need to specify what you want to override.
@@ -597,3 +655,4 @@ Integration tests spin up local HTTP, DNS, and WebSocket servers and exercise th
 | Probe (DNS) | `sendit probe example.com` → prints NOERROR/latency per query |
 | Pinch (TCP) | `sendit pinch example.com:80` → prints open/closed/filtered + latency per check |
 | Pinch (UDP) | `sendit pinch 8.8.8.8:53 --type udp` → prints open/closed/open\|filtered per check |
+| Docker | `cd docker && docker compose up --build` → container starts; `curl localhost:9090/healthz` returns `{"status":"ok"}` |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -92,12 +92,12 @@ Public reference documentation hosted on GitHub Pages.
 
 ---
 
-## v0.7.0 — Container support
+## v0.7.0 — Container support ✓
 
 Package sendit as a Docker image for portability and scheduled runs in CI or on a server.
 
-- Multi-stage `Dockerfile`: `golang:1.22-alpine` builder → `alpine` runtime
-- `docker-compose.yml` with optional Prometheus + Grafana sidecars for out-of-the-box dashboards
+- Multi-stage `Dockerfile`: `golang:1.24-alpine` builder → `alpine` runtime (files under `docker/`)
+- `docker-compose.yml` with optional Prometheus + Grafana sidecars via `--profile observability`
 - Config mounted as a volume so the image stays generic
 - `--foreground` set by default in the entrypoint (PID files are not useful inside a container)
 - `/healthz` endpoint on the metrics port for container liveness checks

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1
+
+# ── builder ──────────────────────────────────────────────────────────────────
+FROM golang:1.24-alpine AS builder
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /sendit ./cmd/sendit
+
+# ── runtime ──────────────────────────────────────────────────────────────────
+FROM alpine:3.21
+
+# ca-certificates: needed for HTTPS targets
+# tzdata: correct timestamps in logs
+RUN apk add --no-cache ca-certificates tzdata
+
+COPY --from=builder /sendit /usr/local/bin/sendit
+
+# Config is mounted at runtime; provide a placeholder so the binary can
+# start without a volume when no config is supplied.
+RUN mkdir -p /etc/sendit
+
+EXPOSE 9090
+
+ENTRYPOINT ["sendit", "start", "--foreground", "--config", "/etc/sendit/config.yaml"]

--- a/docker/config.yaml
+++ b/docker/config.yaml
@@ -1,0 +1,37 @@
+# sendit Docker example config
+# Mount this file at /etc/sendit/config.yaml in the container.
+# Adjust targets, pacing, and rate limits for your use case.
+
+pacing:
+  mode: rate_limited
+  requests_per_minute: 10
+
+limits:
+  max_workers: 4
+  cpu_threshold_pct: 70.0
+  memory_threshold_mb: 256
+
+rate_limits:
+  default_rps: 0.2
+
+backoff:
+  initial_ms: 1000
+  max_ms: 60000
+  multiplier: 2.0
+  max_attempts: 3
+
+targets:
+  - url: "https://httpbin.org/get"
+    weight: 1
+    type: http
+    http:
+      method: GET
+      timeout_s: 15
+
+metrics:
+  enabled: true
+  prometheus_port: 9090
+
+daemon:
+  log_level: info
+  log_format: json   # JSON is friendlier for container log aggregation

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  sendit:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    volumes:
+      - ./config.yaml:/etc/sendit/config.yaml:ro
+    ports:
+      - "9090:9090"
+    restart: unless-stopped
+
+  # ── optional observability stack ─────────────────────────────────────────
+  # Start with: docker compose --profile observability up
+  prometheus:
+    image: prom/prometheus:latest
+    profiles: [observability]
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9091:9090"
+    restart: unless-stopped
+    depends_on:
+      - sendit
+
+  grafana:
+    image: grafana/grafana:latest
+    profiles: [observability]
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    ports:
+      - "3000:3000"
+    restart: unless-stopped
+    depends_on:
+      - prometheus

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: sendit
+    static_configs:
+      - targets: ["sendit:9090"]

--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -108,6 +108,40 @@ By default `start` writes a PID file to `/tmp/sendit.pid` so you can manage the 
 
 Use `--foreground` to skip the PID file (useful in containers or CI).
 
+## Run with Docker
+
+The `docker/` directory in the repository contains a ready-to-use setup. No binary download needed — the image builds from source.
+
+```sh
+# Copy and edit the example config
+cp docker/config.yaml docker/my-config.yaml
+
+# Build and run
+cd docker
+docker compose up --build
+```
+
+Prometheus metrics and the `/healthz` liveness endpoint are exposed on port **9090**:
+
+```sh
+curl localhost:9090/healthz
+# {"status":"ok"}
+```
+
+To also start Prometheus and Grafana:
+
+```sh
+docker compose --profile observability up --build
+```
+
+| Service | Port | URL |
+|---------|------|-----|
+| sendit | 9090 | `http://localhost:9090/metrics` |
+| Prometheus | 9091 | `http://localhost:9091` |
+| Grafana | 3000 | `http://localhost:3000` |
+
+See [docker/config.yaml](https://github.com/lewta/sendit/blob/main/docker/config.yaml) for the Docker-optimised config example.
+
 ## Dry-run mode
 
 Preview effective config — targets, weights, pacing — without sending any traffic:

--- a/docs/content/docs/metrics.md
+++ b/docs/content/docs/metrics.md
@@ -15,7 +15,19 @@ metrics:
   prometheus_port: 9090
 ```
 
-Metrics are then available at `http://localhost:9090/metrics`.
+Two endpoints are available on the configured port:
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /metrics` | Prometheus scrape endpoint |
+| `GET /healthz` | Liveness probe — always returns `200 {"status":"ok"}` |
+
+Useful for container health checks:
+
+```sh
+curl http://localhost:9090/healthz
+# {"status":"ok"}
+```
 
 ## Metric reference
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -91,9 +91,17 @@ func (m *Metrics) Record(r task.Result) {
 
 // ServeHTTP starts the Prometheus metrics HTTP endpoint and shuts it down
 // gracefully when ctx is cancelled. Call in a goroutine.
+//
+// Routes:
+//   - /metrics — Prometheus scrape endpoint
+//   - /healthz — liveness probe; always returns 200 {"status":"ok"}
 func (m *Metrics) ServeHTTP(ctx context.Context, port int) {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{}))
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
 
 	srv := &http.Server{
 		Addr:              fmt.Sprintf(":%d", port),


### PR DESCRIPTION
## Summary

- Adds `docker/` directory with a multi-stage `Dockerfile` (`golang:1.24-alpine` → `alpine` runtime)
- `docker-compose.yml` starts sendit alone by default; add `--profile observability` to also spin up Prometheus (port 9091) and Grafana (port 3000)
- `docker/config.yaml` is a Docker-ready example config with metrics enabled and JSON log format
- `docker/prometheus.yml` configures Prometheus to scrape sendit at `sendit:9090`
- Adds `/healthz` liveness endpoint to the metrics HTTP server (`GET /healthz` → `{"status":"ok"}`)
- Documents Docker usage in `README.md`, `docs/content/docs/getting-started.md`, and `docs/content/docs/metrics.md`
- Marks v0.7.0 ✓ in `ROADMAP.md`

The existing GoReleaser binary builds are unchanged — Docker is an optional deployment method.

## Test plan

- [ ] `go build ./...` — compiles clean
- [ ] `go test -race ./...` — all tests pass including metrics package
- [ ] `curl localhost:9090/healthz` returns `{"status":"ok"}` when metrics are enabled
- [ ] `cd docker && docker compose up --build` — container starts and serves `/metrics` and `/healthz`
- [ ] `docker compose --profile observability up --build` — Prometheus and Grafana also start

🤖 Generated with [Claude Code](https://claude.com/claude-code)