### PR TITLE
feat(metrics): add domain label to metrics (v0.8.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,9 +554,9 @@ Exposed metrics:
 
 | Metric | Type | Labels |
 |--------|------|--------|
-| `sendit_requests_total` | Counter | `type`, `status_code` |
-| `sendit_errors_total` | Counter | `type`, `error_class` |
-| `sendit_request_duration_seconds` | Histogram | `type` |
+| `sendit_requests_total` | Counter | `type`, `domain`, `status_code` |
+| `sendit_errors_total` | Counter | `type`, `domain`, `error_class` |
+| `sendit_request_duration_seconds` | Histogram | `type`, `domain` |
 | `sendit_bytes_read_total` | Counter | `type` |
 
 ### `daemon`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -104,7 +104,7 @@ Package sendit as a Docker image for portability and scheduled runs in CI or on 
 
 ---
 
-## v0.8.0 — Observability improvements
+## v0.8.0 — Observability improvements ✓
 
 Better visibility into per-target behaviour from Prometheus metrics.
 

--- a/docs/content/docs/metrics.md
+++ b/docs/content/docs/metrics.md
@@ -33,14 +33,18 @@ curl http://localhost:9090/healthz
 
 | Metric | Type | Labels | Description |
 |---|---|---|---|
-| `sendit_requests_total` | Counter | `type`, `status_code` | Total requests dispatched, by driver type and status code |
-| `sendit_errors_total` | Counter | `type`, `error_class` | Total errors, by driver type and error class (`transient` or `permanent`) |
-| `sendit_request_duration_seconds` | Histogram | `type` | Request latency distribution, by driver type |
+| `sendit_requests_total` | Counter | `type`, `domain`, `status_code` | Total requests dispatched, by driver type, domain, and status code |
+| `sendit_errors_total` | Counter | `type`, `domain`, `error_class` | Total errors, by driver type, domain, and error class |
+| `sendit_request_duration_seconds` | Histogram | `type`, `domain` | Request latency distribution, by driver type and domain |
 | `sendit_bytes_read_total` | Counter | `type` | Total bytes received, by driver type |
+
+> **Breaking change (v0.8.0):** `sendit_requests_total`, `sendit_errors_total`, and `sendit_request_duration_seconds` gained a `domain` label. Update any existing dashboards or alert rules that match these metrics by label set.
 
 ### Label values
 
 **`type`** matches the `type` field in your target config: `http`, `browser`, `dns`, or `websocket`.
+
+**`domain`** is the hostname extracted from the target URL (e.g. `example.com`, `api.example.com`). For DNS targets with bare hostnames the value is the hostname itself.
 
 **`status_code`** is the HTTP status code (e.g. `200`, `429`, `503`) or the DNS-mapped equivalent (see [Drivers — DNS](../drivers/#dns)).
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/lewta/sendit/internal/task"
@@ -31,19 +32,19 @@ func New() *Metrics {
 		registry: reg,
 		requestsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "sendit_requests_total",
-			Help: "Total number of requests dispatched, by type and status code.",
-		}, []string{"type", "status_code"}),
+			Help: "Total number of requests dispatched, by type, domain, and status code.",
+		}, []string{"type", "domain", "status_code"}),
 
 		errorsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "sendit_errors_total",
-			Help: "Total number of request errors, by type.",
-		}, []string{"type", "error_class"}),
+			Help: "Total number of request errors, by type and domain.",
+		}, []string{"type", "domain", "error_class"}),
 
 		durationSeconds: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "sendit_request_duration_seconds",
-			Help:    "Request duration in seconds, by type.",
+			Help:    "Request duration in seconds, by type and domain.",
 			Buckets: prometheus.DefBuckets,
-		}, []string{"type"}),
+		}, []string{"type", "domain"}),
 
 		bytesRead: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "sendit_bytes_read_total",
@@ -64,9 +65,9 @@ func New() *Metrics {
 // Noop returns a Metrics instance that does nothing (used when metrics disabled).
 func Noop() *Metrics {
 	return &Metrics{
-		requestsTotal:   prometheus.NewCounterVec(prometheus.CounterOpts{Name: "noop_requests"}, []string{"type", "status_code"}),
-		errorsTotal:     prometheus.NewCounterVec(prometheus.CounterOpts{Name: "noop_errors"}, []string{"type", "error_class"}),
-		durationSeconds: prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "noop_duration"}, []string{"type"}),
+		requestsTotal:   prometheus.NewCounterVec(prometheus.CounterOpts{Name: "noop_requests"}, []string{"type", "domain", "status_code"}),
+		errorsTotal:     prometheus.NewCounterVec(prometheus.CounterOpts{Name: "noop_errors"}, []string{"type", "domain", "error_class"}),
+		durationSeconds: prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: "noop_duration"}, []string{"type", "domain"}),
 		bytesRead:       prometheus.NewCounterVec(prometheus.CounterOpts{Name: "noop_bytes"}, []string{"type"}),
 	}
 }
@@ -74,19 +75,30 @@ func Noop() *Metrics {
 // Record observes the result of a completed task.
 func (m *Metrics) Record(r task.Result) {
 	t := r.Task.Type
-	m.durationSeconds.WithLabelValues(t).Observe(r.Duration.Seconds())
+	d := domainOf(r.Task.URL)
+	m.durationSeconds.WithLabelValues(t, d).Observe(r.Duration.Seconds())
 
 	if r.BytesRead > 0 {
 		m.bytesRead.WithLabelValues(t).Add(float64(r.BytesRead))
 	}
 
 	if r.Error != nil {
-		m.errorsTotal.WithLabelValues(t, "error").Inc()
+		m.errorsTotal.WithLabelValues(t, d, "error").Inc()
 		return
 	}
 
 	code := fmt.Sprintf("%d", r.StatusCode)
-	m.requestsTotal.WithLabelValues(t, code).Inc()
+	m.requestsTotal.WithLabelValues(t, d, code).Inc()
+}
+
+// domainOf extracts the hostname from a URL string.
+// For bare hostnames (DNS targets) it returns the string as-is.
+func domainOf(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return rawURL
+	}
+	return u.Hostname() // strips port if present
 }
 
 // ServeHTTP starts the Prometheus metrics HTTP endpoint and shuts it down

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -103,3 +103,26 @@ func TestRecord_AllDriverTypes(t *testing.T) {
 		m.Record(r) // must not panic
 	}
 }
+
+// TestDomainOf verifies domain extraction from various URL formats.
+func TestDomainOf(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"https://example.com", "example.com"},
+		{"https://example.com/path/to/page", "example.com"},
+		{"https://example.com:443/path", "example.com"},
+		{"http://sub.domain.example.com", "sub.domain.example.com"},
+		{"wss://stream.example.com/feed", "stream.example.com"},
+		{"example.com", "example.com"},                   // bare hostname (DNS target)
+		{"notfound.example.com", "notfound.example.com"}, // bare DNS hostname
+	}
+
+	for _, c := range cases {
+		got := domainOf(c.input)
+		if got != c.want {
+			t.Errorf("domainOf(%q) = %q, want %q", c.input, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a `domain` label (hostname from target URL) to `sendit_requests_total`, `sendit_errors_total`, and `sendit_request_duration_seconds`
- `sendit_bytes_read_total` is unchanged (domain not needed for byte accounting)
- `domainOf()` helper: strips scheme and port; bare hostnames (DNS targets) are returned as-is
- Adds `TestDomainOf` covering HTTP, HTTPS, WSS, port-bearing URLs, and bare hostnames
- Updates metric tables in `README.md` and `docs/content/docs/metrics.md` with new label sets and breaking-change note
- Marks v0.8.0 ✓ in `ROADMAP.md`

> **Breaking change:** `sendit_requests_total`, `sendit_errors_total`, and `sendit_request_duration_seconds` have a new `domain` label. Update any existing dashboards or alert rules accordingly.

## Test plan

- [ ] `go test -race ./...` passes
- [ ] Metrics endpoint shows `domain="example.com"` label on requests to `https://example.com`
- [ ] DNS targets with bare hostnames show the hostname as domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)