### PR TITLE
docs: sync documentation for v0.6.0–v0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://img.shields.io/github/actions/workflow/status/lewta/sendit/ci.yml?branch=main&label=tests)](https://github.com/lewta/sendit/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/lewta/sendit)](https://github.com/lewta/sendit/releases/latest)
-[![Go version](https://img.shields.io/badge/go-1.22+-00ADD8?logo=go&logoColor=white)](https://go.dev)
+[![Go version](https://img.shields.io/badge/go-1.24+-00ADD8?logo=go&logoColor=white)](https://go.dev)
 [![Go Report Card](https://goreportcard.com/badge/github.com/lewta/sendit)](https://goreportcard.com/report/github.com/lewta/sendit)
 [![License](https://img.shields.io/github/license/lewta/sendit)](LICENSE)
 
@@ -21,7 +21,7 @@ Key properties:
 
 ### Prerequisites
 
-- Go 1.22+
+- Go 1.24+
 - Chrome/Chromium (only required for `type: browser` targets)
 
 ### Build
@@ -603,6 +603,7 @@ internal/output/                JSONL / CSV result writer (non-blocking, gorouti
 config/example.yaml             Full reference configuration (with target_defaults section)
 config/targets.txt              Example targets file (url + type per line)
 config/test.yaml                Lightweight HTTP+DNS config for local smoke-testing
+docker/                         Container deployment: Dockerfile, docker-compose, example config
 ```
 
 ### Browser driver

--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -28,7 +28,7 @@ Press Ctrl-C to stop and print a summary. See the [CLI Reference](cli/) for all 
 
 | Section | What you'll find |
 |---|---|
-| [Getting Started](getting-started/) | Install, build, validate a config, and run your first traffic |
+| [Getting Started](getting-started/) | Install, build, validate a config, run your first traffic, and deploy with Docker |
 | [Configuration](configuration/) | Every config key, its type, default, and description |
 | [Pacing Modes](pacing/) | `human`, `rate_limited`, and `scheduled` — how request timing works |
 | [Drivers](drivers/) | `http`, `browser`, `dns`, `websocket` — options and examples for each |

--- a/docs/content/docs/configuration.md
+++ b/docs/content/docs/configuration.md
@@ -142,10 +142,17 @@ Optional Prometheus exposition endpoint.
 ```yaml
 metrics:
   enabled: true
-  prometheus_port: 9090   # GET http://localhost:9090/metrics
+  prometheus_port: 9090
 ```
 
-See [Metrics](../metrics/) for the full metric table.
+When enabled, two endpoints are served on `prometheus_port`:
+
+| Endpoint | Description |
+|---|---|
+| `GET /metrics` | Prometheus scrape endpoint |
+| `GET /healthz` | Liveness probe — always returns `200 {"status":"ok"}` |
+
+See [Metrics](../metrics/) for the full metric reference and label descriptions.
 
 ## `daemon`
 

--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -7,7 +7,7 @@ description: "Install sendit, validate a config, and run your first traffic."
 
 ## Prerequisites
 
-- **Go 1.22+** — required to build from source
+- **Go 1.24+** — required to build from source
 - **Chrome or Chromium** — only required for `type: browser` targets
 - The `sendit` binary runs on Linux, macOS, and Windows
 


### PR DESCRIPTION
## Summary

Documentation audit covering all changes from v0.6.0 through v0.8.0. No code changes.

**Gaps found and fixed:**

| Location | Gap | Fix |
|---|---|---|
| `README.md` badge | Go version badge said `1.22+` | Updated to `1.24+` (matches go.mod) |
| `README.md` prerequisites | "Go 1.22+" | Updated to "Go 1.24+" |
| `README.md` architecture tree | `docker/` directory missing | Added with description |
| `docs/content/docs/getting-started.md` | "Go 1.22+" | Updated to "Go 1.24+" |
| `docs/content/docs/configuration.md` `metrics` section | `/healthz` endpoint not mentioned | Added endpoint table (v0.7.0) |
| `docs/content/docs/_index.md` sections table | Getting Started row didn't mention Docker | Updated description |

**Already current (no changes needed):**
- `cmd/sendit/main.go` CLI help text — pinch, probe, start, reload, stop, validate all correct
- `docs/cli.md` — all commands, flags, and examples current
- `docs/metrics.md` — domain label and /healthz already updated in v0.7.0/v0.8.0 PRs
- `docs/drivers.md` — no driver changes in this range
- `docs/pacing.md` — no pacing changes in this range

🤖 Generated with [Claude Code](https://claude.com/claude-code)