### PR TITLE
feat(release): expand OS/arch build matrix (v0.8.1, closes #29)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,9 +12,33 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
+      - freebsd
     goarch:
       - amd64
       - arm64
+      - arm
+      - "386"
+    goarm:
+      - "7"
+    ignore:
+      # darwin only ships amd64 and arm64
+      - goos: darwin
+        goarch: arm
+      - goos: darwin
+        goarch: "386"
+      # windows only ships amd64 and arm64
+      - goos: windows
+        goarch: arm
+      - goos: windows
+        goarch: "386"
+      # freebsd only ships amd64
+      - goos: freebsd
+        goarch: arm64
+      - goos: freebsd
+        goarch: arm
+      - goos: freebsd
+        goarch: "386"
     ldflags:
       - -s -w
       - -X main.version={{.Version}}
@@ -23,7 +47,10 @@ builds:
 
 archives:
   - formats: [tar.gz]
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    format_overrides:
+      - goos: windows
+        formats: [zip]
 
 checksum:
   name_template: "checksums.txt"

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ sendit completion <shell>
 | `probe`      | Test a single HTTP or DNS endpoint in a loop (like ping). No config file required. |
 | `pinch`      | Check whether a TCP or UDP port is open on a remote host, repeating on an interval. No config file required. |
 | `stop`       | Send SIGTERM to a running instance via its PID file. |
-| `reload`     | Send SIGHUP to a running instance via its PID file to reload the config atomically. |
+| `reload`     | Send SIGHUP to a running instance via its PID file to reload the config atomically. Not available on Windows — use a full restart instead. |
 | `status`     | Check whether the process in the PID file is still alive. |
 | `validate`   | Parse and validate a config file without starting the engine. Exits 0 on success, non-zero with a message on failure. |
 | `version`    | Print version, commit, and build date. |

--- a/cmd/sendit/main.go
+++ b/cmd/sendit/main.go
@@ -576,7 +576,10 @@ func reloadCmd() *cobra.Command {
 
 Targets, rate limits, backoff settings, and pacing parameters are reloaded
 atomically with no dropped requests. Changes to pacing mode, worker count,
-CPU/memory limits, or output settings require a full restart.`,
+CPU/memory limits, or output settings require a full restart.
+
+Note: SIGHUP is not available on Windows. Use a full restart to reload
+config on Windows.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			pid, err := readPID(pidFile)
 			if err != nil {

--- a/docs/content/docs/cli.md
+++ b/docs/content/docs/cli.md
@@ -180,6 +180,8 @@ min/avg/max latency: 4ms / 4ms / 4ms
 |---|---|---|
 | `--pid-file` | `/tmp/sendit.pid` | Path to PID file written by `start` |
 
+> **Windows:** SIGHUP is not available on Windows. `sendit reload` will not work — use a full restart to pick up config changes.
+
 ## `validate` flags
 
 | Flag | Short | Default | Description |


### PR DESCRIPTION
## Summary

Expands GoReleaser build targets from 4 to 9 artifacts, and documents the Windows SIGHUP limitation.

### New build targets

| OS | Arch | Format |
|---|---|---|
| linux | amd64, arm64 | tar.gz (unchanged) |
| linux | arm/v7 | tar.gz (new) |
| linux | 386 | tar.gz (new) |
| darwin | amd64, arm64 | tar.gz (unchanged) |
| windows | amd64, arm64 | **zip** (new) |
| freebsd | amd64 | tar.gz (new) |

`CGO_ENABLED=0` was already set so cross-compilation requires no additional toolchain setup.

Archive name template updated to append `v7` suffix for ARM v7 builds (e.g. `sendit_0.8.1_linux_armv7.tar.gz`).

### Windows note

SIGHUP is not available on Windows, so `sendit reload` won't work there. Documented in:
- `cmd/sendit/main.go` reload command `Long` description
- `README.md` command table
- `docs/content/docs/cli.md` stop/reload/status section

## Test plan

- [ ] `go build ./...` and `go test -race ./...` pass
- [ ] CI passes
- [ ] After merge and tag, GoReleaser produces 9 release artifacts + checksums.txt

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)