### PR TITLE
fix: switch license badge to static (avoids shields.io API failures)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Release](https://img.shields.io/github/v/release/lewta/sendit)](https://github.com/lewta/sendit/releases/latest)
 [![Go version](https://img.shields.io/badge/go-1.24+-00ADD8?logo=go&logoColor=white)](https://go.dev)
 [![Go Report Card](https://goreportcard.com/badge/github.com/lewta/sendit)](https://goreportcard.com/report/github.com/lewta/sendit)
-[![License](https://img.shields.io/github/license/lewta/sendit)](LICENSE)
+[![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
 A Go CLI tool that simulates realistic user web traffic across HTTP, headless browser, DNS, and WebSocket protocols. Designed to blend into normal traffic baselines while being polite to both the local machine and target servers.
 


### PR DESCRIPTION
## Problem

The `github/license` shields.io badge makes a live API call to GitHub at render time. When shields.io's request is rate-limited or hits a transient error it shows **"invalid"** instead of the license name.

GitHub's API correctly returns `{"spdx_id": "MIT"}` for this repo — the issue is entirely on shields.io's side.

## Fix

Switch to a static badge:

```
![License](https://img.shields.io/badge/license-MIT-blue)
```

Static badges never fail — they render from the URL alone with no external API call. Since the license is MIT and won't change, there's no downside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)