### PR TITLE
feat(probe): WebSocket support in sendit probe (v0.9.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ target_defaults:
 
 ```
 sendit start    [-c <path>] [--foreground] [--log-level debug|info|warn|error] [--dry-run]
-sendit probe    <target>   [--type http|dns] [--interval 1s] [--timeout 5s]
+sendit probe    <target>   [--type http|dns|websocket] [--interval 1s] [--timeout 5s] [--send <msg>]
 sendit pinch    <host:port> [--type tcp|udp] [--interval 1s] [--timeout 5s]
 sendit stop     [--pid-file <path>]
 sendit reload   [--pid-file <path>]
@@ -101,7 +101,7 @@ sendit completion <shell>
 | Command      | Description |
 |--------------|-------------|
 | `start`      | Start the engine. Writes a PID file by default so `stop`/`status` can find the process; use `--foreground` to skip writing the PID file. |
-| `probe`      | Test a single HTTP or DNS endpoint in a loop (like ping). No config file required. |
+| `probe`      | Test a single HTTP, DNS, or WebSocket endpoint in a loop (like ping). No config file required. |
 | `pinch`      | Check whether a TCP or UDP port is open on a remote host, repeating on an interval. No config file required. |
 | `stop`       | Send SIGTERM to a running instance via its PID file. |
 | `reload`     | Send SIGHUP to a running instance via its PID file to reload the config atomically. Not available on Windows — use a full restart instead. |
@@ -123,11 +123,12 @@ sendit completion <shell>
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--type` | *(auto-detected)* | Driver type: `http` \| `dns` |
+| `--type` | *(auto-detected)* | Driver type: `http` \| `dns` \| `websocket` |
 | `--interval` | `1s` | Delay between requests |
 | `--timeout` | `5s` | Per-request timeout |
 | `--resolver` | `8.8.8.8:53` | DNS resolver (dns targets only) |
 | `--record-type` | `A` | DNS record type (dns targets only) |
+| `--send` | `""` | Message to send after connecting (websocket only); waits for one reply and reports round-trip latency |
 
 ### `pinch` flags
 
@@ -181,7 +182,7 @@ Limits:
 
 ## Probe
 
-`sendit probe <target>` tests a single HTTP or DNS endpoint in a loop with no config file. Press Ctrl-C to stop and print a summary.
+`sendit probe <target>` tests a single HTTP, DNS, or WebSocket endpoint in a loop with no config file. Press Ctrl-C to stop and print a summary.
 
 **Type auto-detection:**
 
@@ -189,9 +190,11 @@ Limits:
 |---|---|
 | `https://example.com` | `http` |
 | `http://example.com` | `http` |
+| `wss://example.com` | `websocket` |
+| `ws://example.com` | `websocket` |
 | `example.com` | `dns` |
 
-Override with `--type http` or `--type dns`.
+Override with `--type http`, `--type dns`, or `--type websocket`.
 
 **HTTP example:**
 
@@ -229,6 +232,44 @@ Probing example.com (dns, A @ 1.1.1.1:53) — Ctrl-C to stop
 --- example.com ---
 3 sent, 3 ok, 0 error(s)
 min/avg/max latency: 8ms / 10ms / 12ms
+```
+
+**WebSocket example (connect only):**
+
+```sh
+./sendit probe wss://echo.websocket.org
+```
+
+```
+Probing wss://echo.websocket.org (websocket, connect only) — Ctrl-C to stop
+
+  101    38ms
+  101    41ms
+  101    36ms
+^C
+
+--- wss://echo.websocket.org ---
+3 sent, 3 ok, 0 error(s)
+min/avg/max latency: 36ms / 38ms / 41ms
+```
+
+**WebSocket example (send + receive round-trip):**
+
+```sh
+./sendit probe wss://echo.websocket.org --send 'ping'
+```
+
+```
+Probing wss://echo.websocket.org (websocket, send+recv) — Ctrl-C to stop
+
+  101    42ms
+  101    39ms
+  101    44ms
+^C
+
+--- wss://echo.websocket.org ---
+3 sent, 3 ok, 0 error(s)
+min/avg/max latency: 39ms / 41ms / 44ms
 ```
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -113,7 +113,7 @@ Better visibility into per-target behaviour from Prometheus metrics.
 
 ---
 
-## v0.9.0 — Probe WebSocket
+## v0.9.0 — Probe WebSocket ✓
 
 Complete driver coverage in the probe tool.
 

--- a/cmd/sendit/main.go
+++ b/cmd/sendit/main.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/coder/websocket"
 	"github.com/lewta/sendit/internal/config"
 	"github.com/lewta/sendit/internal/driver"
 	"github.com/lewta/sendit/internal/engine"
@@ -39,7 +40,7 @@ Targets are defined in a YAML config file under 'targets' (inline) and/or
 loaded from a plain-text file via 'targets_file'. Both can be used together.
 
 Use 'sendit probe <target>' to test a single endpoint interactively without
-a config file — works like ping for HTTP and DNS targets.
+a config file — works like ping for HTTP, DNS, and WebSocket targets.
 
 Use 'sendit pinch <host:port>' to check TCP/UDP port connectivity without
 a config file.
@@ -74,21 +75,29 @@ func probeCmd() *cobra.Command {
 		timeout    time.Duration
 		resolver   string
 		recordType string
+		sendMsg    string
 	)
 
 	cmd := &cobra.Command{
 		Use:   "probe <target>",
-		Short: "Test a single endpoint in a loop (like ping for HTTP/DNS)",
-		Long: `Probe an HTTP or DNS endpoint in a loop until stopped.
+		Short: "Test a single endpoint in a loop (like ping for HTTP/DNS/WebSocket)",
+		Long: `Probe an HTTP, DNS, or WebSocket endpoint in a loop until stopped.
 
 No config file is required. The driver type is auto-detected from the target:
   https:// or http:// prefix → http
+  wss:// or ws:// prefix     → websocket
   bare hostname              → dns
+
+For WebSocket targets, each iteration connects, optionally sends a message and
+waits for one reply, then closes the connection. Use --send to trigger the
+send/receive round-trip measurement.
 
 Examples:
   sendit probe https://example.com
   sendit probe example.com
-  sendit probe example.com --type dns --record-type AAAA --resolver 1.1.1.1:53`,
+  sendit probe example.com --type dns --record-type AAAA --resolver 1.1.1.1:53
+  sendit probe wss://echo.example.com
+  sendit probe wss://echo.example.com --send '{"type":"ping"}'`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			target := args[0]
@@ -96,8 +105,8 @@ Examples:
 			if driverType == "" {
 				driverType = detectProbeType(target)
 			}
-			if driverType != "http" && driverType != "dns" {
-				return fmt.Errorf("probe supports http and dns targets; got type %q", driverType)
+			if driverType != "http" && driverType != "dns" && driverType != "websocket" {
+				return fmt.Errorf("probe supports http, dns, and websocket targets; got type %q", driverType)
 			}
 
 			t := task.Task{
@@ -129,9 +138,18 @@ Examples:
 			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 			defer stop()
 
-			header := fmt.Sprintf("Probing %s (http)", target)
-			if driverType == "dns" {
+			var header string
+			switch driverType {
+			case "dns":
 				header = fmt.Sprintf("Probing %s (dns, %s @ %s)", target, strings.ToUpper(recordType), resolver)
+			case "websocket":
+				if sendMsg != "" {
+					header = fmt.Sprintf("Probing %s (websocket, send+recv)", target)
+				} else {
+					header = fmt.Sprintf("Probing %s (websocket, connect only)", target)
+				}
+			default:
+				header = fmt.Sprintf("Probing %s (http)", target)
 			}
 			fmt.Printf("\n%s — Ctrl-C to stop\n\n", header)
 
@@ -145,30 +163,46 @@ Examples:
 
 			run := func() {
 				execCtx, cancel := context.WithTimeout(ctx, timeout)
-				result := drv.Execute(execCtx, t)
-				cancel()
+				defer cancel()
+
+				var (
+					status int
+					dur    time.Duration
+					bytes  int64
+					err    error
+				)
+
+				if driverType == "websocket" {
+					status, dur, err = probeWS(execCtx, target, sendMsg)
+				} else {
+					result := drv.Execute(execCtx, t)
+					status, dur, bytes, err = result.StatusCode, result.Duration, result.BytesRead, result.Error
+				}
 
 				total++
-				dur := result.Duration.Round(time.Millisecond)
+				displayDur := dur.Round(time.Millisecond)
 
-				if result.Error != nil {
-					fmt.Printf("  ERR  %v\n", result.Error)
+				if err != nil {
+					fmt.Printf("  ERR  %v\n", err)
 					return
 				}
 
 				success++
-				sumDur += result.Duration
-				if success == 1 || result.Duration < minDur {
-					minDur = result.Duration
+				sumDur += dur
+				if success == 1 || dur < minDur {
+					minDur = dur
 				}
-				if result.Duration > maxDur {
-					maxDur = result.Duration
+				if dur > maxDur {
+					maxDur = dur
 				}
 
-				if driverType == "dns" {
-					fmt.Printf("  %-8s  %6s\n", probeRcodeLabel(result.StatusCode), dur)
-				} else {
-					fmt.Printf("  %3d  %6s  %s\n", result.StatusCode, dur, probeFormatBytes(result.BytesRead))
+				switch driverType {
+				case "dns":
+					fmt.Printf("  %-8s  %6s\n", probeRcodeLabel(status), displayDur)
+				case "websocket":
+					fmt.Printf("  %3d  %6s\n", status, displayDur)
+				default:
+					fmt.Printf("  %3d  %6s  %s\n", status, displayDur, probeFormatBytes(bytes))
 				}
 			}
 
@@ -188,20 +222,48 @@ Examples:
 		},
 	}
 
-	cmd.Flags().StringVar(&driverType, "type", "", "Driver type: http|dns (auto-detected from target if omitted)")
+	cmd.Flags().StringVar(&driverType, "type", "", "Driver type: http|dns|websocket (auto-detected from target if omitted)")
 	cmd.Flags().DurationVar(&interval, "interval", time.Second, "Delay between requests")
 	cmd.Flags().DurationVar(&timeout, "timeout", 5*time.Second, "Per-request timeout")
 	cmd.Flags().StringVar(&resolver, "resolver", "8.8.8.8:53", "DNS resolver address (dns targets only)")
 	cmd.Flags().StringVar(&recordType, "record-type", "A", "DNS record type (dns targets only)")
+	cmd.Flags().StringVar(&sendMsg, "send", "", "Message to send after connecting (websocket only); waits for one reply and reports round-trip latency")
 
 	return cmd
 }
 
 func detectProbeType(target string) string {
-	if strings.HasPrefix(target, "http://") || strings.HasPrefix(target, "https://") {
+	switch {
+	case strings.HasPrefix(target, "http://") || strings.HasPrefix(target, "https://"):
 		return "http"
+	case strings.HasPrefix(target, "ws://") || strings.HasPrefix(target, "wss://"):
+		return "websocket"
+	default:
+		return "dns"
 	}
-	return "dns"
+}
+
+// probeWS dials a WebSocket endpoint, optionally sends sendMsg and reads one
+// reply, then closes gracefully. Returns status 101 on success.
+func probeWS(ctx context.Context, target, sendMsg string) (int, time.Duration, error) {
+	start := time.Now()
+	conn, _, err := websocket.Dial(ctx, target, nil)
+	if err != nil {
+		return 0, time.Since(start), fmt.Errorf("dial: %w", err)
+	}
+	defer conn.CloseNow() //nolint:errcheck
+
+	if sendMsg != "" {
+		if err := conn.Write(ctx, websocket.MessageText, []byte(sendMsg)); err != nil {
+			return 0, time.Since(start), fmt.Errorf("send: %w", err)
+		}
+		if _, _, err := conn.Read(ctx); err != nil {
+			return 0, time.Since(start), fmt.Errorf("recv: %w", err)
+		}
+	}
+
+	conn.Close(websocket.StatusNormalClosure, "done") //nolint:errcheck,gosec
+	return 101, time.Since(start), nil
 }
 
 func probeRcodeLabel(status int) string {

--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -12,14 +12,16 @@ Two commands let you verify connectivity instantly without writing a config file
 
 | Command | What it does |
 |---|---|
-| [`sendit probe <target>`](cli/#probe-flags) | Test a single HTTP or DNS endpoint in a loop. Auto-detects the driver from the URL. Works like `ping` for web targets. |
+| [`sendit probe <target>`](cli/#probe-flags) | Test a single HTTP, DNS, or WebSocket endpoint in a loop. Auto-detects the driver from the URL. Works like `ping` for web targets. |
 | [`sendit pinch <host:port>`](cli/#pinch-flags) | Check whether a TCP or UDP port is open on a remote host, repeating on an interval. |
 
 ```sh
-sendit probe https://example.com       # HTTP — prints status, latency, bytes per request
-sendit probe example.com               # DNS  — prints RCODE and latency per query
-sendit pinch example.com:443           # TCP  — prints open/closed/filtered per check
-sendit pinch 8.8.8.8:53 --type udp    # UDP  — prints open/closed/open|filtered per check
+sendit probe https://example.com            # HTTP — prints status, latency, bytes per request
+sendit probe example.com                    # DNS  — prints RCODE and latency per query
+sendit probe wss://echo.websocket.org       # WebSocket — prints status and connect latency
+sendit probe wss://echo.websocket.org --send 'ping'  # WebSocket — send+recv round-trip
+sendit pinch example.com:443                # TCP  — prints open/closed/filtered per check
+sendit pinch 8.8.8.8:53 --type udp         # UDP  — prints open/closed/open|filtered per check
 ```
 
 Press Ctrl-C to stop and print a summary. See the [CLI Reference](cli/) for all flags.

--- a/docs/content/docs/cli.md
+++ b/docs/content/docs/cli.md
@@ -9,7 +9,7 @@ description: "All sendit commands and their flags."
 
 ```
 sendit start    [-c <path>] [--foreground] [--log-level debug|info|warn|error] [--dry-run]
-sendit probe    <target>    [--type http|dns] [--interval 1s] [--timeout 5s]
+sendit probe    <target>    [--type http|dns|websocket] [--interval 1s] [--timeout 5s] [--send <msg>]
 sendit pinch    <host:port> [--type tcp|udp] [--interval 1s] [--timeout 5s]
 sendit stop     [--pid-file <path>]
 sendit reload   [--pid-file <path>]
@@ -22,7 +22,7 @@ sendit completion <shell>
 | Command | Description |
 |---|---|
 | `start` | Start the engine. Writes a PID file by default so `stop`/`status` can find the process; use `--foreground` to skip. |
-| `probe` | Test a single HTTP or DNS endpoint in a loop (like ping). No config file needed. |
+| `probe` | Test a single HTTP, DNS, or WebSocket endpoint in a loop (like ping). No config file needed. |
 | `pinch` | Check whether a TCP or UDP port is open on a remote host, repeating on an interval. No config file needed. |
 | `stop` | Send SIGTERM to the running instance via its PID file. Waits for in-flight requests to finish. |
 | `reload` | Send SIGHUP to the running instance via its PID file to hot-reload config atomically. |
@@ -68,11 +68,12 @@ Limits:
 
 | Flag | Default | Description |
 |---|---|---|
-| `--type` | *(auto-detected)* | Driver type: `http` \| `dns` |
+| `--type` | *(auto-detected)* | Driver type: `http` \| `dns` \| `websocket` |
 | `--interval` | `1s` | Delay between requests |
 | `--timeout` | `5s` | Per-request timeout |
 | `--resolver` | `8.8.8.8:53` | DNS resolver (dns targets only) |
 | `--record-type` | `A` | DNS record type (dns targets only) |
+| `--send` | `""` | Message to send after connecting (websocket only); waits for one reply and reports round-trip latency |
 
 **Auto-detection rules:**
 
@@ -80,6 +81,8 @@ Limits:
 |---|---|
 | `https://example.com` | `http` |
 | `http://example.com` | `http` |
+| `wss://example.com` | `websocket` |
+| `ws://example.com` | `websocket` |
 | `example.com` | `dns` |
 
 ### HTTP probe example
@@ -116,6 +119,42 @@ Probing example.com (dns, A @ 1.1.1.1:53) — Ctrl-C to stop
 --- example.com ---
 2 sent, 2 ok, 0 error(s)
 min/avg/max latency: 8ms / 10ms / 12ms
+```
+
+### WebSocket probe example (connect only)
+
+```sh
+./sendit probe wss://echo.websocket.org
+```
+
+```
+Probing wss://echo.websocket.org (websocket, connect only) — Ctrl-C to stop
+
+  101    38ms
+  101    41ms
+^C
+
+--- wss://echo.websocket.org ---
+2 sent, 2 ok, 0 error(s)
+min/avg/max latency: 38ms / 39ms / 41ms
+```
+
+### WebSocket probe example (send + receive round-trip)
+
+```sh
+./sendit probe wss://echo.websocket.org --send 'ping'
+```
+
+```
+Probing wss://echo.websocket.org (websocket, send+recv) — Ctrl-C to stop
+
+  101    42ms
+  101    39ms
+^C
+
+--- wss://echo.websocket.org ---
+2 sent, 2 ok, 0 error(s)
+min/avg/max latency: 39ms / 40ms / 42ms
 ```
 
 ## `pinch` flags

--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -34,9 +34,15 @@ Download the latest binary for your platform from the [releases page](https://gi
 
 # DNS (bare hostname)
 ./sendit probe example.com
+
+# WebSocket (wss:// or ws://) — connect only
+./sendit probe wss://echo.websocket.org
+
+# WebSocket — send a message and measure round-trip latency
+./sendit probe wss://echo.websocket.org --send 'ping'
 ```
 
-Each request prints status, latency, and bytes (HTTP) or RCODE (DNS). Press Ctrl-C for a summary:
+Each request prints status, latency, and bytes (HTTP) or RCODE (DNS) or status code (WebSocket). Press Ctrl-C for a summary:
 
 ```
 Probing https://example.com (http) — Ctrl-C to stop


### PR DESCRIPTION
## Summary

Extends `sendit probe` to support WebSocket targets, completing driver coverage in the probe tool.

### Behaviour

- `wss://` and `ws://` URLs are auto-detected as `websocket` type (new entry in `detectProbeType`)
- Each iteration: dial → optionally send `--send` message + read one reply → close gracefully
- Without `--send`: measures connect latency only; header says `(websocket, connect only)`
- With `--send <msg>`: measures full send+receive round-trip; header says `(websocket, send+recv)`
- Output line: `  101   42ms` — status code + latency, no bytes column (consistent with DNS probe style)
- Summary format identical to HTTP/DNS probe

### Implementation

`probeWS()` is a self-contained function in `main.go` (same pattern as `pinchTCP`/`pinchUDP`) using `github.com/coder/websocket` directly — avoids the existing `WebSocketDriver` which is designed for long-held connections with `duration_s`, not quick connect/ping cycles.

### Example output

```
$ sendit probe wss://echo.websocket.org --send 'ping'

Probing wss://echo.websocket.org (websocket, send+recv) — Ctrl-C to stop

  101    42ms
  101    39ms
^C

--- wss://echo.websocket.org ---
2 sent, 2 ok, 0 error(s)
min/avg/max latency: 39ms / 40ms / 42ms
```

### Docs updated
- `cmd/sendit/main.go` — probe `Long`, flag description, root `Long`
- `README.md` — commands block, probe flags table, auto-detection table, WebSocket examples
- `docs/content/docs/cli.md` — same
- `docs/content/docs/getting-started.md` — probe quick-start examples
- `docs/content/docs/_index.md` — quick tools table and code examples

## Test plan

- [ ] `go test -race ./...` passes
- [ ] `sendit probe wss://echo.websocket.org` connects and prints `101` + latency
- [ ] `sendit probe wss://echo.websocket.org --send 'ping'` prints round-trip latency
- [ ] `sendit probe wss://localhost:19999` prints `ERR dial: ...` and continues
- [ ] `sendit probe example.com` still works (DNS auto-detect unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)