### PR TITLE
fix(ci): update GoReleaser v2 skip flags and migrate brews to homebrew_casks

### DIFF
--- a/.github/workflows/release-taps.yml
+++ b/.github/workflows/release-taps.yml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: read
-  actions: read # needed to download artifacts from the triggering workflow run
 
 jobs:
   update-taps:
@@ -28,16 +27,6 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      # Restore the pre-built binaries so GoReleaser can archive them and
-      # compute the SHA256 hashes that go into the formula/manifest.
-      - name: Download dist from Release workflow
-        uses: actions/download-artifact@v4
-        with:
-          name: goreleaser-dist
-          path: dist/
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Get release tag
         id: tag
         run: echo "value=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
@@ -53,20 +42,21 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: homebrew-tap,scoop-bucket
 
+      # Rebuilds binaries and archives from scratch (CGO_ENABLED=0 + -trimpath
+      # makes Go builds deterministic, so SHA256 matches what was uploaded).
       # Skips everything already done by the Release workflow:
-      #   build     — binaries are in dist/ (restored above)
       #   validate  — already validated
       #   publish   — GitHub release already exists
       #   nfpm      — .deb/.rpm already uploaded
-      #   source    — source archive already uploaded
       #   announce  — don't announce twice
       #   sign      — already signed (if applicable)
-      # What runs: before hooks (completions), archive, checksum, brew, scoop.
+      # What runs: before hooks (completions), build, archive, checksum,
+      #            homebrew_casks (formula → tap), scoop (manifest → bucket).
       - name: Push Homebrew formula and Scoop manifest
         uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
-          args: release --skip=build,validate,publish,nfpm,source,announce,sign
+          args: release --skip=validate,publish,nfpm,announce,sign
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_PAT: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
-          args: release --clean --skip=brew,scoop
+          args: release --clean --skip=homebrew,scoop
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -50,16 +50,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
-          args: release --clean --skip=brew,scoop
+          args: release --clean --skip=homebrew,scoop
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ github.event.inputs.tag }}
-
-      # dist/ is uploaded so the tap-update workflow can use the pre-built
-      # binaries to generate a formula/manifest with the correct SHA256 hashes.
-      - name: Upload dist for tap update
-        uses: actions/upload-artifact@v4
-        with:
-          name: goreleaser-dist
-          path: dist/
-          retention-days: 1

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -58,8 +58,14 @@ archives:
     files:
       - completions/*
 
-brews:
+homebrew_casks:
   - name: sendit
+    binaries:
+      - sendit
+    completions:
+      bash: completions/sendit.bash
+      zsh: completions/sendit.zsh
+      fish: completions/sendit.fish
     repository:
       owner: lewta
       name: homebrew-tap
@@ -67,13 +73,6 @@ brews:
     homepage: "https://github.com/lewta/sendit"
     description: "Traffic generation tool for HTTP, DNS, WebSocket, and headless-browser targets."
     license: "MIT"
-    install: |
-      bin.install "sendit"
-      bash_completion.install "completions/sendit.bash" => "sendit"
-      zsh_completion.install "completions/sendit.zsh" => "_sendit"
-      fish_completion.install "completions/sendit.fish"
-    test: |
-      system "#{bin}/sendit", "version"
 
 nfpms:
   - package_name: sendit


### PR DESCRIPTION
## What broke

GoReleaser v2.14.2 renamed the Homebrew skip flag from `brew` to `homebrew`. The release workflow was passing `--skip=brew,scoop`, which failed immediately at flag validation before any build step ran. No partial release was created.

## Changes

- `.goreleaser.yaml` — migrate `brews:` → `homebrew_casks:` (the v2 replacement); replace manual Ruby `install:` / `test:` blocks with structured `binaries:` and `completions:` fields; config validates cleanly with no warnings
- `release.yml` — `--skip=brew,scoop` → `--skip=homebrew,scoop`; remove unused `dist/` artifact upload
- `release-taps.yml` — remove `--skip=build,source` (not valid skip flags in v2); remove unused `dist/` download step; the tap-update job rebuilds binaries deterministically (CGO_ENABLED=0 + -trimpath = same SHA256 as the release job)

## Verified

```
$ goreleaser check
  • checking  path=.goreleaser.yaml
  • 1 configuration file(s) validated
  • thanks for using GoReleaser!
```

## After merge

Re-tag `v0.10.0` on the new main commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)