### PR TITLE
fix(metrics): use bounded shutdown context to satisfy gosec G118

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -125,7 +125,11 @@ func (m *Metrics) ServeHTTP(ctx context.Context, port int) {
 
 	go func() {
 		<-ctx.Done()
-		if err := srv.Shutdown(context.Background()); err != nil {
+		// ctx is already cancelled here; use a fresh context so the graceful
+		// shutdown is not immediately aborted.
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second) //nolint:gosec // G118: intentional — parent ctx is done, shutdown needs its own deadline
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
 			log.Error().Err(err).Msg("metrics server shutdown error")
 		}
 	}()


### PR DESCRIPTION
## Problem

golangci-lint v2.11.2 introduced gosec rule G118 which flags `context.Background()` inside a goroutine when a request-scoped context is in scope. The lint job on main started failing with:

```
internal/metrics/metrics.go:126:2: G118: Goroutine uses context.Background/TODO
while request-scoped context is available (gosec)
```

## Fix

The usage is semantically correct — `ctx` is already cancelled when `srv.Shutdown` is called (we're in the `<-ctx.Done()` branch), so it can't be reused for shutdown. The fix:

1. Wraps `context.Background()` in a 5-second timeout, which is also good practice for bounded graceful shutdowns
2. Adds an explanatory `//nolint:gosec` comment documenting why the fresh context is intentional

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test -race ./internal/metrics/...` passes
- [ ] CI lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)