### PR TITLE
fix: move gosec nolint to goroutine line and use sh -c for completions

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,9 +4,9 @@ before:
   hooks:
     - go mod tidy
     - mkdir -p completions
-    - go run ./cmd/sendit completion bash > completions/sendit.bash
-    - go run ./cmd/sendit completion zsh > completions/sendit.zsh
-    - go run ./cmd/sendit completion fish > completions/sendit.fish
+    - sh -c 'go run ./cmd/sendit completion bash > completions/sendit.bash'
+    - sh -c 'go run ./cmd/sendit completion zsh > completions/sendit.zsh'
+    - sh -c 'go run ./cmd/sendit completion fish > completions/sendit.fish'
 
 builds:
   - main: ./cmd/sendit

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -123,11 +123,11 @@ func (m *Metrics) ServeHTTP(ctx context.Context, port int) {
 
 	log.Info().Str("addr", srv.Addr).Msg("prometheus metrics endpoint listening")
 
-	go func() {
+	go func() { //nolint:gosec // G118: intentional — parent ctx is done, shutdown needs its own deadline
 		<-ctx.Done()
 		// ctx is already cancelled here; use a fresh context so the graceful
 		// shutdown is not immediately aborted.
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second) //nolint:gosec // G118: intentional — parent ctx is done, shutdown needs its own deadline
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if err := srv.Shutdown(shutdownCtx); err != nil {
 			log.Error().Err(err).Msg("metrics server shutdown error")


### PR DESCRIPTION
## Two fixes in one

### 1. gosec G118 nolint on wrong line

G118 fires on the `go func()` declaration (line 126), not on the `context.WithTimeout` call. The previous fix placed `//nolint:gosec` on line 130, which had no effect. Moved to the goroutine line.

### 2. GoReleaser completions not generated

GoReleaser before hooks run via `exec` without a shell, so `>` in:
```
go run ./cmd/sendit completion bash > completions/sendit.bash
```
was passed as a literal argument rather than a shell redirect — the file was never created. This caused:
- `no files matched glob=completions/*` warnings during archiving (completions absent from tarballs)
- `nfpm failed: file does not exist` hard error when building `.deb`/`.rpm`

Fix: wrap each completion hook in `sh -c '...'` so the shell handles the redirect.

```yaml
- sh -c 'go run ./cmd/sendit completion bash > completions/sendit.bash'
```

## After merge

Delete and re-push `v0.10.0` tag on the new main commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)