### PR TITLE
fix(ci): use release.disable template to skip GitHub publisher in tap update

### DIFF
--- a/.github/workflows/release-taps.yml
+++ b/.github/workflows/release-taps.yml
@@ -44,20 +44,18 @@ jobs:
 
       # Rebuilds binaries and archives from scratch (CGO_ENABLED=0 + -trimpath
       # makes Go builds deterministic, so SHA256 matches what was uploaded).
-      # Skips everything already done by the Release workflow:
-      #   validate  — already validated
-      #   publish   — GitHub release already exists
-      #   nfpm      — .deb/.rpm already uploaded
-      #   announce  — don't announce twice
-      #   sign      — already signed (if applicable)
-      # What runs: before hooks (completions), build, archive, checksum,
-      #            homebrew_casks (formula → tap), scoop (manifest → bucket).
+      # SKIP_GH_RELEASE=true uses the release.skip template in .goreleaser.yaml
+      # to skip only the GitHub release publisher, while still allowing
+      # homebrew_casks and scoop to push their formula/manifest to the tap and
+      # bucket repos. Without this, --skip=publish would suppress all
+      # publishers including the tap/bucket push.
       - name: Push Homebrew formula and Scoop manifest
         uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
-          args: release --skip=validate,publish,nfpm,announce,sign
+          args: release --skip=validate,nfpm,announce,sign
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_PAT: ${{ steps.app-token.outputs.token }}
           GORELEASER_CURRENT_TAG: ${{ steps.tag.outputs.value }}
+          SKIP_GH_RELEASE: "true"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -100,6 +100,14 @@ scoops:
     description: Traffic generation tool for HTTP, DNS, WebSocket, and headless-browser targets.
     license: MIT
 
+# SKIP_GH_RELEASE=true disables only the GitHub release publisher, while still
+# allowing homebrew_casks and scoop to push their formula/manifest. Used by
+# release-taps.yml to avoid re-creating a release that already exists. The
+# download URLs in the formula/manifest are computed from the tag and are
+# valid because release.yml already created the release.
+release:
+  disable: '{{ envOrDefault "SKIP_GH_RELEASE" "false" }}'
+
 checksum:
   name_template: "checksums.txt"
 


### PR DESCRIPTION
## Root cause

`--skip=publish` in GoReleaser v2 suppresses **all** publishers — including homebrew_casks and scoop — not just the GitHub release upload. The tap-update job was completing successfully (GoReleaser wrote the files to `dist/`) but never pushed them to `lewta/homebrew-tap` or `lewta/scoop-bucket`.

## Fix

Add a `release.disable` template field in `.goreleaser.yaml` controlled by a `SKIP_GH_RELEASE` env var:

```yaml
release:
  disable: '{{ envOrDefault "SKIP_GH_RELEASE" "false" }}'
```

- `release.yml` — does not set `SKIP_GH_RELEASE` → evaluates to `"false"` → GitHub release created normally
- `release-taps.yml` — sets `SKIP_GH_RELEASE: "true"` → evaluates to `"true"` → GitHub release publisher disabled, homebrew_casks and scoop publishers still run and push

Remove `--skip=publish` from `release-taps.yml` args since it's now handled by the config template.

## After merge

Re-run the existing `Update taps` workflow run (no re-tag needed, GitHub release already exists):
```sh
gh run rerun <run-id> --repo lewta/sendit
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)