### PR TITLE
fix(ci): use .Env template syntax for release.disable condition

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -106,7 +106,7 @@ scoops:
 # download URLs in the formula/manifest are computed from the tag and are
 # valid because release.yml already created the release.
 release:
-  disable: '{{ envOrDefault "SKIP_GH_RELEASE" "false" }}'
+  disable: '{{ if eq .Env.SKIP_GH_RELEASE "true" }}true{{ else }}false{{ end }}'
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
## Problem

`envOrDefault` is not a GoReleaser template function. The template:
```yaml
release:
  disable: '{{ envOrDefault "SKIP_GH_RELEASE" "false" }}'
```
silently returned an empty string (falsy), so `release.disable` never activated. GoReleaser then tried to update the existing GitHub release and failed with `403 Resource not accessible by integration` — the `release-taps.yml` job only has `contents: read`.

## Fix

Use GoReleaser's `.Env` map, which is the documented way to access environment variables in templates:
```yaml
release:
  disable: '{{ if eq .Env.SKIP_GH_RELEASE "true" }}true{{ else }}false{{ end }}'
```

Verified locally:
```
$ SKIP_GH_RELEASE=true goreleaser check
  • pipe skipped or partially skipped  reason=release is disabled
  • 1 configuration file(s) validated
```

## After merge

Trigger manually:
```sh
gh workflow run "Update taps" --repo lewta/sendit --field tag=v0.10.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)