### PR TITLE
ci(release): overlay .goreleaser.yaml from main in update-taps job

### DIFF
--- a/.github/workflows/release-taps.yml
+++ b/.github/workflows/release-taps.yml
@@ -49,6 +49,13 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: homebrew-tap,scoop-bucket
 
+      # The tag commit may predate fixes to .goreleaser.yaml. Overlay the
+      # current config from main so we always use the latest pipeline config
+      # while keeping all source files at the tag commit (CGO_ENABLED=0 +
+      # -trimpath makes Go builds deterministic, so SHA256 still matches).
+      - name: Use current GoReleaser config from main
+        run: git show origin/main:.goreleaser.yaml > .goreleaser.yaml
+
       # Rebuilds binaries and archives from scratch (CGO_ENABLED=0 + -trimpath
       # makes Go builds deterministic, so SHA256 matches what was uploaded).
       # SKIP_GH_RELEASE=true uses the release.disable template in .goreleaser.yaml


### PR DESCRIPTION
## Summary

- Adds a step in `release-taps.yml` that overlays `.goreleaser.yaml` from `origin/main` after checking out the tag commit
- Fixes the v0.10.0 tap update failure: the tag predated the `envOrDefault` → `.Env` template fix (PR #85), so GoReleaser was trying to PATCH an existing GitHub release and getting 403

## Why this is safe

Go builds are deterministic when `CGO_ENABLED=0` is set (no cgo) and `-trimpath` is in ldflags. The source files stay at the tag commit, so the resulting binaries and their SHA256 checksums are identical to what was uploaded in the original Release workflow run. Only the pipeline config (`.goreleaser.yaml`) is swapped for the current version.

## Test plan

- [ ] Merge PR
- [ ] Trigger `Update taps` manually: `gh workflow run "Update taps" --repo lewta/sendit --field tag=v0.10.0`
- [ ] Confirm `lewta/homebrew-tap` has `Casks/sendit.rb`
- [ ] Confirm `lewta/scoop-bucket` has `sendit.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)