### PR TITLE
ci(release): replace release.disable with skip_upload + mode: keep-existing

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -100,13 +100,13 @@ scoops:
     description: Traffic generation tool for HTTP, DNS, WebSocket, and headless-browser targets.
     license: MIT
 
-# SKIP_GH_RELEASE=true disables only the GitHub release publisher, while still
-# allowing homebrew_casks and scoop to push their formula/manifest. Used by
-# release-taps.yml to avoid re-creating a release that already exists. The
-# download URLs in the formula/manifest are computed from the tag and are
-# valid because release.yml already created the release.
+# SKIP_GH_RELEASE=true skips artifact uploads and keeps the existing release
+# unchanged. Used by release-taps.yml: GoReleaser reads the existing release
+# to compute download URLs for the homebrew cask and scoop manifest, then
+# pushes those to the tap/bucket repos — without touching the release itself.
 release:
-  disable: '{{ if eq .Env.SKIP_GH_RELEASE "true" }}true{{ else }}false{{ end }}'
+  skip_upload: '{{ if eq .Env.SKIP_GH_RELEASE "true" }}true{{ else }}false{{ end }}'
+  mode: keep-existing
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
## Problem

`release.disable: true` prevented GoReleaser from computing download URLs for `homebrew_casks` and `scoops`:
```
release is disabled, cannot use default url_template
```

`url_template` is not a configurable field on `homebrew_casks`, so there's no workaround — the release publisher must be enabled for URL computation to work.

## Fix

- Replace `release.disable` template with `release.skip_upload` — GoReleaser reads the existing GitHub release to compute download URLs but does not re-upload any artifacts
- Add `mode: keep-existing` — prevents modifying release metadata; GoReleaser only does a GET to retrieve the release URL context
- The `release-taps.yml` workflow still has `contents: read` permission; no write calls are needed since no release data is modified

## Validation

```
SKIP_GH_RELEASE=true goreleaser check   # → 1 configuration file(s) validated
goreleaser check                         # → 1 configuration file(s) validated
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)