### PR TITLE
ci(release): grant contents: write to update-taps job

### DIFF
--- a/.github/workflows/release-taps.yml
+++ b/.github/workflows/release-taps.yml
@@ -17,7 +17,7 @@ on:
         required: true
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   update-taps:
@@ -58,10 +58,10 @@ jobs:
 
       # Rebuilds binaries and archives from scratch (CGO_ENABLED=0 + -trimpath
       # makes Go builds deterministic, so SHA256 matches what was uploaded).
-      # SKIP_GH_RELEASE=true uses the release.disable template in .goreleaser.yaml
-      # to skip only the GitHub release publisher, while still allowing
-      # homebrew_casks and scoop to push their formula/manifest to the tap and
-      # bucket repos.
+      # SKIP_GH_RELEASE=true sets release.skip_upload=true + mode=keep-existing
+      # in .goreleaser.yaml: GoReleaser reads the existing release for URL
+      # computation and PATCHes its metadata (requires contents: write), but
+      # does NOT re-upload any artifacts.
       - name: Push Homebrew formula and Scoop manifest
         uses: goreleaser/goreleaser-action@v7
         with:


### PR DESCRIPTION
## Problem

GoReleaser PATCHes the GitHub release to update metadata (title, notes, draft status) even when `skip_upload: true` and `mode: keep-existing` are set. The previous `contents: read` permission caused a 403 on that PATCH call.

## Fix

- Upgrade `permissions.contents` to `write` in `release-taps.yml`
- Artifact re-uploads are still prevented by `release.skip_upload: true` (set via `SKIP_GH_RELEASE=true`)
- `mode: keep-existing` preserves existing release assets

The App token is scoped only to `homebrew-tap` and `scoop-bucket` — it has no access to `lewta/sendit`. The `GITHUB_TOKEN` is the only credential with access to the release, and GoReleaser's config prevents it from uploading artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)