### PR TITLE
docs: fix OG description and add v0.10.0 install methods

### DIFF
--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -7,11 +7,47 @@ description: "Install sendit, validate a config, and run your first traffic."
 
 ## Prerequisites
 
-- **Go 1.24+** — required to build from source
 - **Chrome or Chromium** — only required for `type: browser` targets
 - The `sendit` binary runs on Linux, macOS, and Windows
 
-## Build from source
+## Install
+
+### Homebrew (macOS and Linux)
+
+```sh
+brew install lewta/tap/sendit
+```
+
+Shell completions for bash, zsh, and fish are installed automatically.
+
+### Scoop (Windows)
+
+```powershell
+scoop bucket add lewta https://github.com/lewta/scoop-bucket
+scoop install sendit
+```
+
+### Linux packages
+
+Download the `.deb` or `.rpm` package for your architecture from the [releases page](https://github.com/lewta/sendit/releases/latest):
+
+```sh
+# Debian / Ubuntu
+sudo dpkg -i sendit_<version>_linux_amd64.deb
+
+# Fedora / RHEL / CentOS
+sudo rpm -i sendit_<version>_linux_amd64.rpm
+```
+
+Shell completions are installed to the system completion directories automatically.
+
+### Binary download
+
+Download the pre-built archive for your platform from the [releases page](https://github.com/lewta/sendit/releases/latest), extract it, and place the binary in your `$PATH`.
+
+### Build from source
+
+Requires **Go 1.24+**.
 
 ```sh
 git clone https://github.com/lewta/sendit
@@ -19,10 +55,6 @@ cd sendit
 go build -o sendit ./cmd/sendit
 ./sendit version
 ```
-
-## Pre-built binaries
-
-Download the latest binary for your platform from the [releases page](https://github.com/lewta/sendit/releases/latest).
 
 ## Test an endpoint without a config file
 

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -9,6 +9,9 @@ enableGitInfo = true
   [[module.imports]]
     path = "github.com/gohugoio/hugo-mod-bootstrap-scss/v5"
 
+[params]
+  description = "A flexible traffic generator for HTTP, browser, DNS, and WebSocket targets. Polite by design — paced, rate-limited, and resource-gated."
+
 [params.docs]
   title           = "sendit"
   themeColor      = "blue"


### PR DESCRIPTION
## Changes

### Fix #74 — link preview shows Hugo template

`og:description` on the landing page fell through to `Site.Params.description`, which was unset → chat apps showed blank or theme-default preview text. Fixed by adding `description` under `[params]` in `hugo.toml`.

### v0.10.0 install methods

`getting-started.md` only documented building from source and binary downloads. Added:
- **Homebrew** — `brew install lewta/tap/sendit`
- **Scoop** — `scoop bucket add lewta ... && scoop install sendit`
- **.deb / .rpm** — `dpkg -i` / `rpm -i` with a note on automatic completions
- Binary download (was "pre-built binaries", now properly labelled)
- Build from source moved to last (least convenient option)

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)