### PR TITLE
ci: add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,60 @@
+# Dependabot auto-merge
+#
+# TRIGGER: fires on every pull_request event; job guard limits execution to
+#          Dependabot PRs only (github.actor == 'dependabot[bot]').
+#
+# RISK EVALUATION: uses dependabot/fetch-metadata to classify the update.
+#   - github-actions (any update type): always auto-merged — actions in this
+#     repo are pinned to SHAs, so a "version bump" changes a tag alias, not code.
+#   - semver-patch or semver-minor: auto-merged — CI (lint + test) is the real
+#     safety gate. Semver is a pre-filter to keep major surprises out of the queue.
+#   - semver-major (non-actions): held for manual review.
+#
+# RELEASE: this workflow does NOT cut a release. release.yml only fires on
+#          `push: tags: "v*"`. Merging to main does not push a tag.
+#
+# AUTO-MERGE: gh pr merge --auto --squash queues the merge but GitHub executes
+#             it only after all required checks (lint, test) pass.
+
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a  # v2.5.0
+
+      - name: Approve
+        if: |
+          steps.meta.outputs.package-ecosystem == 'github-actions' ||
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: |
+          gh pr review "$PR_URL" \
+            --approve \
+            --body "Auto-approved: ${{ steps.meta.outputs.update-type }} (${{ steps.meta.outputs.package-ecosystem }}). CI required before merge."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        if: |
+          steps.meta.outputs.package-ecosystem == 'github-actions' ||
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Adds `.github/workflows/dependabot-automerge.yml` — a CI-gated auto-approve and squash-merge workflow for Dependabot PRs.

## How it works

**Trigger:** `pull_request` targeting `main`. Job guard: `if: github.actor == 'dependabot[bot]'` — non-Dependabot PRs do nothing.

**Risk evaluation via `dependabot/fetch-metadata`:**

| Update type | Action |
|-------------|--------|
| `github-actions` (any semver) | Auto-approve + auto-merge — actions are SHA-pinned so "version bump" changes an alias, not code |
| `semver-patch` | Auto-approve + auto-merge — CI is the real gate |
| `semver-minor` | Auto-approve + auto-merge — CI is the real gate |
| `semver-major` | No action — held for manual review |

**Merge:** `gh pr merge --auto --squash` — queues the merge; GitHub executes it only after `lint` and `test` (the required checks) pass. Does not force-merge.

## Will this cut a release?

No. `release.yml` only fires on `push: tags: "v*"`. Merging to main does not push a tag.

## Open PRs

PRs 217 and 218 (the two pending Dependabot PRs) predate this workflow, so it won't auto-fire on them. Once this is merged, enable auto-merge manually:
```
gh pr merge --auto --squash 217
gh pr merge --auto --squash 218
```

## Security

- Uses `secrets.GITHUB_TOKEN` (built-in, zero external secrets)
- `pull_request` (not `pull_request_target`) — no elevated fork permissions
- `dependabot/fetch-metadata` pinned to SHA `21025c705c08248db411dc16f3619e6b5f9ea21a` (v2.5.0)