### PR TITLE
chore: group CodeQL action Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,7 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      codeql-action:
+        patterns:
+          - github/codeql-action*


### PR DESCRIPTION
## Summary
- Group `github/codeql-action*` GitHub Actions updates in Dependabot
- Keeps CodeQL `init`, `autobuild`, `analyze`, and related sub-actions on coherent pinned SHAs

## Why
The current split Dependabot PRs can produce mixed CodeQL action versions, which caused the `autobuild` PR to fail with a config/action version mismatch.

## Testing
- Config-only change; not run locally.