### PR TITLE
fix: block cross-host HTTP redirects by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,6 +687,7 @@ target_defaults:
     headers:
       User-Agent: "Mozilla/5.0 ..."
     timeout_s: 15
+    allow_cross_host_redirects: false
   browser:
     scroll: false
     timeout_s: 30
@@ -706,6 +707,7 @@ target_defaults:
 | `auth.type` | `""` | Auth type: `bearer` \| `basic` \| `header` \| `query` |
 | `http.method` | `GET` | HTTP verb |
 | `http.timeout_s` | `15` | Request timeout in seconds |
+| `http.allow_cross_host_redirects` | `false` | Follow redirects to a different host. Keep disabled when sending auth headers unless that forwarding is intended. |
 | `browser.timeout_s` | `30` | Page load timeout in seconds |
 | `dns.resolver` | `8.8.8.8:53` | DNS resolver address |
 | `dns.record_type` | `A` | DNS record type |

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -52,6 +52,7 @@ target_defaults:
     headers:
       User-Agent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"
     timeout_s: 15
+    # allow_cross_host_redirects: false  # opt in only when redirects to other hosts are expected
   browser:
     scroll: false
     timeout_s: 30

--- a/docs/content/docs/configuration.md
+++ b/docs/content/docs/configuration.md
@@ -120,6 +120,7 @@ target_defaults:
 | `auth.type` | `""` | Auth type: `bearer` \| `basic` \| `header` \| `query` — see [Drivers](../drivers/#auth-block) |
 | `http.method` | `GET` | HTTP verb |
 | `http.timeout_s` | `15` | Request timeout (seconds) |
+| `http.allow_cross_host_redirects` | `false` | Follow redirects to a different host. Keep disabled when sending auth headers unless that forwarding is intended. |
 | `browser.timeout_s` | `30` | Page load timeout (seconds) |
 | `dns.resolver` | `8.8.8.8:53` | DNS resolver address |
 | `dns.record_type` | `A` | DNS record type |

--- a/docs/content/docs/drivers.md
+++ b/docs/content/docs/drivers.md
@@ -70,6 +70,7 @@ targets:
         Accept: "application/json"
       body: '{"key":"value"}'            # optional request body (string)
       timeout_s: 15                      # per-request timeout in seconds
+      allow_cross_host_redirects: false  # opt in to follow redirects to another host
 ```
 
 | Field | Default | Description |
@@ -78,6 +79,7 @@ targets:
 | `headers` | `{}` | Key-value map of request headers |
 | `body` | `""` | Optional request body |
 | `timeout_s` | `15` | Per-request timeout (seconds) |
+| `allow_cross_host_redirects` | `false` | Follow redirects to a different host. Keep disabled when sending auth headers unless that forwarding is intended. |
 
 > **Note:** HTTP header map keys are lowercased by the YAML parser (e.g. `User-Agent` is stored as `user-agent`). This is standard YAML behaviour.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,6 +79,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("target_defaults.weight", 1)
 	v.SetDefault("target_defaults.http.method", "GET")
 	v.SetDefault("target_defaults.http.timeout_s", 15)
+	v.SetDefault("target_defaults.http.allow_cross_host_redirects", false)
 	v.SetDefault("target_defaults.browser.timeout_s", 30)
 	v.SetDefault("target_defaults.dns.resolver", "8.8.8.8:53")
 	v.SetDefault("target_defaults.dns.record_type", "A")

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -107,10 +107,11 @@ type AuthConfig struct {
 
 // HTTPConfig holds HTTP-specific target settings.
 type HTTPConfig struct {
-	Method   string            `mapstructure:"method"`
-	Headers  map[string]string `mapstructure:"headers"`
-	Body     string            `mapstructure:"body"`
-	TimeoutS int               `mapstructure:"timeout_s"`
+	Method                  string            `mapstructure:"method"`
+	Headers                 map[string]string `mapstructure:"headers"`
+	Body                    string            `mapstructure:"body"`
+	TimeoutS                int               `mapstructure:"timeout_s"`
+	AllowCrossHostRedirects bool              `mapstructure:"allow_cross_host_redirects"`
 }
 
 // BrowserConfig holds headless-browser target settings.

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -123,6 +124,102 @@ func TestHTTPDriver_CustomHeaders(t *testing.T) {
 	}
 	if gotHeader != "sendit-test" {
 		t.Errorf("server received header %q, want sendit-test", gotHeader)
+	}
+}
+
+func TestHTTPDriver_CustomAuthHeader_NotForwardedToCrossHostRedirect(t *testing.T) {
+	var redirectedRequests atomic.Int32
+	var gotHeader string
+	dst := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectedRequests.Add(1)
+		gotHeader = r.Header.Get("X-API-Key")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer dst.Close()
+
+	src := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, dst.URL, http.StatusFound)
+	}))
+	defer src.Close()
+
+	drv := driver.NewHTTPDriver()
+	t1 := httpTask(src.URL, config.HTTPConfig{TimeoutS: 5})
+	t1.Config.Auth = config.AuthConfig{Type: "header", HeaderName: "X-API-Key", Token: "secret"}
+	result := drv.Execute(context.Background(), t1)
+
+	if result.Error != nil {
+		t.Fatalf("unexpected error: %v", result.Error)
+	}
+	if result.StatusCode != http.StatusFound {
+		t.Errorf("StatusCode = %d, want %d", result.StatusCode, http.StatusFound)
+	}
+	if redirectedRequests.Load() != 0 {
+		t.Errorf("redirect target received %d requests, want 0", redirectedRequests.Load())
+	}
+	if gotHeader != "" {
+		t.Errorf("redirect target received auth header %q, want empty", gotHeader)
+	}
+}
+
+func TestHTTPDriver_CustomAuthHeader_ForwardedToCrossHostRedirectWhenAllowed(t *testing.T) {
+	var redirectedRequests atomic.Int32
+	var gotHeader string
+	dst := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectedRequests.Add(1)
+		gotHeader = r.Header.Get("X-API-Key")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer dst.Close()
+
+	src := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, dst.URL, http.StatusFound)
+	}))
+	defer src.Close()
+
+	drv := driver.NewHTTPDriver()
+	t1 := httpTask(src.URL, config.HTTPConfig{TimeoutS: 5, AllowCrossHostRedirects: true})
+	t1.Config.Auth = config.AuthConfig{Type: "header", HeaderName: "X-API-Key", Token: "secret"}
+	result := drv.Execute(context.Background(), t1)
+
+	if result.Error != nil {
+		t.Fatalf("unexpected error: %v", result.Error)
+	}
+	if result.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", result.StatusCode, http.StatusOK)
+	}
+	if redirectedRequests.Load() != 1 {
+		t.Errorf("redirect target received %d requests, want 1", redirectedRequests.Load())
+	}
+	if gotHeader != "secret" {
+		t.Errorf("redirect target received auth header %q, want secret", gotHeader)
+	}
+}
+
+func TestHTTPDriver_CustomAuthHeader_PreservedOnSameHostRedirect(t *testing.T) {
+	var gotHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/start" {
+			http.Redirect(w, r, "/final", http.StatusFound)
+			return
+		}
+		gotHeader = r.Header.Get("X-API-Key")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	drv := driver.NewHTTPDriver()
+	t1 := httpTask(srv.URL+"/start", config.HTTPConfig{TimeoutS: 5})
+	t1.Config.Auth = config.AuthConfig{Type: "header", HeaderName: "X-API-Key", Token: "secret"}
+	result := drv.Execute(context.Background(), t1)
+
+	if result.Error != nil {
+		t.Fatalf("unexpected error: %v", result.Error)
+	}
+	if result.StatusCode != http.StatusOK {
+		t.Errorf("StatusCode = %d, want %d", result.StatusCode, http.StatusOK)
+	}
+	if gotHeader != "secret" {
+		t.Errorf("server received auth header %q, want secret", gotHeader)
 	}
 }
 

--- a/internal/driver/http.go
+++ b/internal/driver/http.go
@@ -29,6 +29,16 @@ func NewHTTPDriver() *HTTPDriver {
 	}
 }
 
+func sameHostRedirectPolicy(req *http.Request, via []*http.Request) error {
+	if len(via) == 0 {
+		return nil
+	}
+	if !strings.EqualFold(req.URL.Host, via[len(via)-1].URL.Host) {
+		return http.ErrUseLastResponse
+	}
+	return nil
+}
+
 // Execute performs the HTTP request described by t.
 func (d *HTTPDriver) Execute(ctx context.Context, t task.Task) task.Result {
 	cfg := t.Config.HTTP
@@ -64,7 +74,13 @@ func (d *HTTPDriver) Execute(ctx context.Context, t task.Task) task.Result {
 	}
 
 	start := time.Now()
-	resp, err := d.client.Do(req)
+	client := d.client
+	if !cfg.AllowCrossHostRedirects {
+		clientCopy := *d.client
+		clientCopy.CheckRedirect = sameHostRedirectPolicy
+		client = &clientCopy
+	}
+	resp, err := client.Do(req)
 	elapsed := time.Since(start)
 
 	if err != nil {


### PR DESCRIPTION
## Summary

Blocks HTTP redirects to a different host by default so custom auth headers such as `X-API-Key` are not forwarded to attacker-controlled redirect targets.

Adds an explicit opt-in bypass for workloads that intentionally rely on cross-host redirects:

```yaml
http:
  allow_cross_host_redirects: true
```

## Why

The HTTP driver previously used Go's default redirect behavior. Go strips standard sensitive headers such as `Authorization` across unsafe redirect boundaries, but arbitrary custom headers configured through `auth.type: header` are not protected the same way. A target that responds with a redirect to another host could therefore receive a request that includes custom secret-bearing headers.

## User impact

Cross-host redirects now return the original `3xx` response unless `http.allow_cross_host_redirects` is enabled. Same-host redirects continue to work by default.

This is a security-minded default behavior change and should be called out in the changelog for the next release. The docs site under `docs/`, the README, and `config/example.yaml` now document the bypass option.

## Validation

```text
GOCACHE=/private/tmp/sendit-gocache GOMODCACHE=/private/tmp/sendit-gomodcache go test ./...
```

Passed locally.