### PR TITLE
fix: rate limit cross-host HTTP redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ under the affected version with a reference to the CVE or advisory.
 
 ## [Unreleased]
 
+### Security
+- Block HTTP redirects to a different host by default to avoid forwarding custom auth headers; set `http.allow_cross_host_redirects: true` to opt in to cross-host redirects.
+- Ensure opt-in cross-host HTTP redirects still pass through per-domain rate limiting before the redirected request is sent.
+
 ### Changed
 - Bump `dorny/paths-filter` from 4.0.1 to 4.0.2 (CI: pinned SHA update)
 - Bump `google.golang.org/grpc` from 1.81.1 to 1.82.0 (routine minor release; transitive bump to `google.golang.org/genproto/googleapis/rpc`)

--- a/README.md
+++ b/README.md
@@ -707,7 +707,7 @@ target_defaults:
 | `auth.type` | `""` | Auth type: `bearer` \| `basic` \| `header` \| `query` |
 | `http.method` | `GET` | HTTP verb |
 | `http.timeout_s` | `15` | Request timeout in seconds |
-| `http.allow_cross_host_redirects` | `false` | Follow redirects to a different host. Keep disabled when sending auth headers unless that forwarding is intended. |
+| `http.allow_cross_host_redirects` | `false` | Follow redirects to a different host. Redirected hosts still use per-domain rate limits. Keep disabled when sending auth headers unless that forwarding is intended. |
 | `browser.timeout_s` | `30` | Page load timeout in seconds |
 | `dns.resolver` | `8.8.8.8:53` | DNS resolver address |
 | `dns.record_type` | `A` | DNS record type |

--- a/docs/content/docs/drivers.md
+++ b/docs/content/docs/drivers.md
@@ -79,7 +79,7 @@ targets:
 | `headers` | `{}` | Key-value map of request headers |
 | `body` | `""` | Optional request body |
 | `timeout_s` | `15` | Per-request timeout (seconds) |
-| `allow_cross_host_redirects` | `false` | Follow redirects to a different host. Keep disabled when sending auth headers unless that forwarding is intended. |
+| `allow_cross_host_redirects` | `false` | Follow redirects to a different host. Redirected hosts still use per-domain rate limits. Keep disabled when sending auth headers unless that forwarding is intended. |
 
 > **Note:** HTTP header map keys are lowercased by the YAML parser (e.g. `User-Agent` is stored as `user-agent`). This is standard YAML behaviour.
 

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -2,10 +2,12 @@ package driver_test
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -164,19 +166,27 @@ func TestHTTPDriver_CustomAuthHeader_NotForwardedToCrossHostRedirect(t *testing.
 func TestHTTPDriver_CustomAuthHeader_ForwardedToCrossHostRedirectWhenAllowed(t *testing.T) {
 	var redirectedRequests atomic.Int32
 	var gotHeader string
+	var limitedHost string
 	dst := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		redirectedRequests.Add(1)
 		gotHeader = r.Header.Get("X-API-Key")
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer dst.Close()
+	dstURL, err := url.Parse(dst.URL)
+	if err != nil {
+		t.Fatalf("parsing dst URL: %v", err)
+	}
 
 	src := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, dst.URL, http.StatusFound)
 	}))
 	defer src.Close()
 
-	drv := driver.NewHTTPDriver()
+	drv := driver.NewHTTPDriverWithRedirectLimiter(func(ctx context.Context, host string) error {
+		limitedHost = host
+		return nil
+	})
 	t1 := httpTask(src.URL, config.HTTPConfig{TimeoutS: 5, AllowCrossHostRedirects: true})
 	t1.Config.Auth = config.AuthConfig{Type: "header", HeaderName: "X-API-Key", Token: "secret"}
 	result := drv.Execute(context.Background(), t1)
@@ -190,8 +200,39 @@ func TestHTTPDriver_CustomAuthHeader_ForwardedToCrossHostRedirectWhenAllowed(t *
 	if redirectedRequests.Load() != 1 {
 		t.Errorf("redirect target received %d requests, want 1", redirectedRequests.Load())
 	}
+	if limitedHost != dstURL.Hostname() {
+		t.Errorf("redirect limiter saw host %q, want %q", limitedHost, dstURL.Hostname())
+	}
 	if gotHeader != "secret" {
 		t.Errorf("redirect target received auth header %q, want secret", gotHeader)
+	}
+}
+
+func TestHTTPDriver_CrossHostRedirectLimiterBlocksRedirect(t *testing.T) {
+	errLimited := errors.New("redirect host rate limited")
+	var redirectedRequests atomic.Int32
+	dst := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectedRequests.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer dst.Close()
+
+	src := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, dst.URL, http.StatusFound)
+	}))
+	defer src.Close()
+
+	drv := driver.NewHTTPDriverWithRedirectLimiter(func(ctx context.Context, host string) error {
+		return errLimited
+	})
+	t1 := httpTask(src.URL, config.HTTPConfig{TimeoutS: 5, AllowCrossHostRedirects: true})
+	result := drv.Execute(context.Background(), t1)
+
+	if !errors.Is(result.Error, errLimited) {
+		t.Fatalf("Error = %v, want %v", result.Error, errLimited)
+	}
+	if redirectedRequests.Load() != 0 {
+		t.Errorf("redirect target received %d requests, want 0", redirectedRequests.Load())
 	}
 }
 

--- a/internal/driver/http.go
+++ b/internal/driver/http.go
@@ -11,14 +11,26 @@ import (
 	"github.com/lewta/sendit/internal/task"
 )
 
+// RedirectLimiter is called before the HTTP driver follows a redirect to a
+// different host.
+type RedirectLimiter func(ctx context.Context, host string) error
+
 // HTTPDriver executes HTTP requests.
 type HTTPDriver struct {
-	client *http.Client
+	client          *http.Client
+	redirectLimiter RedirectLimiter
 }
 
 // NewHTTPDriver creates an HTTPDriver with a shared transport.
 func NewHTTPDriver() *HTTPDriver {
+	return NewHTTPDriverWithRedirectLimiter(nil)
+}
+
+// NewHTTPDriverWithRedirectLimiter creates an HTTPDriver that asks
+// redirectLimiter for permission before following cross-host redirects.
+func NewHTTPDriverWithRedirectLimiter(redirectLimiter RedirectLimiter) *HTTPDriver {
 	return &HTTPDriver{
+		redirectLimiter: redirectLimiter,
 		client: &http.Client{
 			Transport: &http.Transport{
 				MaxIdleConns:        100,
@@ -29,14 +41,30 @@ func NewHTTPDriver() *HTTPDriver {
 	}
 }
 
-func sameHostRedirectPolicy(req *http.Request, via []*http.Request) error {
-	if len(via) == 0 {
-		return nil
+func (d *HTTPDriver) redirectPolicy(allowCrossHost bool) func(req *http.Request, via []*http.Request) error {
+	return func(req *http.Request, via []*http.Request) error {
+		if len(via) == 0 {
+			return nil
+		}
+
+		if strings.EqualFold(req.URL.Host, via[len(via)-1].URL.Host) {
+			return nil
+		}
+
+		if !allowCrossHost {
+			return http.ErrUseLastResponse
+		}
+
+		if d.redirectLimiter == nil {
+			return nil
+		}
+
+		host := req.URL.Hostname()
+		if host == "" {
+			return nil
+		}
+		return d.redirectLimiter(req.Context(), host)
 	}
-	if !strings.EqualFold(req.URL.Host, via[len(via)-1].URL.Host) {
-		return http.ErrUseLastResponse
-	}
-	return nil
 }
 
 // Execute performs the HTTP request described by t.
@@ -74,12 +102,9 @@ func (d *HTTPDriver) Execute(ctx context.Context, t task.Task) task.Result {
 	}
 
 	start := time.Now()
-	client := d.client
-	if !cfg.AllowCrossHostRedirects {
-		clientCopy := *d.client
-		clientCopy.CheckRedirect = sameHostRedirectPolicy
-		client = &clientCopy
-	}
+	clientCopy := *d.client
+	clientCopy.CheckRedirect = d.redirectPolicy(cfg.AllowCrossHostRedirects)
+	client := &clientCopy
 	resp, err := client.Do(req)
 	elapsed := time.Since(start)
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -56,13 +56,6 @@ func New(cfg *config.Config, m *metrics.Metrics) (*Engine, error) {
 		scheduler: NewScheduler(cfg.Pacing),
 		monitor:   resource.New(cfg.Limits.CPUThresholdPct, cfg.Limits.MemoryThresholdMB),
 		metrics:   m,
-		drivers: map[string]driver.Driver{
-			"http":      driver.NewHTTPDriver(),
-			"browser":   driver.NewBrowserDriver(),
-			"dns":       driver.NewDNSDriver(),
-			"websocket": driver.NewWebSocketDriver(),
-			"grpc":      driver.NewGRPCDriver(),
-		},
 	}
 
 	e.cfg.Store(cfg)
@@ -74,6 +67,15 @@ func New(cfg *config.Config, m *metrics.Metrics) (*Engine, error) {
 		cfg.Backoff.Multiplier,
 		cfg.Backoff.MaxAttempts,
 	))
+	e.drivers = map[string]driver.Driver{
+		"http": driver.NewHTTPDriverWithRedirectLimiter(func(ctx context.Context, host string) error {
+			return e.rl.Load().Wait(ctx, host)
+		}),
+		"browser":   driver.NewBrowserDriver(),
+		"dns":       driver.NewDNSDriver(),
+		"websocket": driver.NewWebSocketDriver(),
+		"grpc":      driver.NewGRPCDriver(),
+	}
 
 	if cfg.Output.Enabled {
 		w, err := output.New(cfg.Output)

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1,10 +1,17 @@
 package engine
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/lewta/sendit/internal/config"
 	"github.com/lewta/sendit/internal/metrics"
+	"github.com/lewta/sendit/internal/task"
 )
 
 func baseCfg(targets []config.TargetConfig) *config.Config {
@@ -108,6 +115,77 @@ func TestReload_SwapsBackoff(t *testing.T) {
 	bo := eng.backoff.Load()
 	if got := bo.MaxAttempts(); got != 5 {
 		t.Errorf("backoff MaxAttempts after reload = %d, want 5", got)
+	}
+}
+
+func TestDispatch_RateLimitsCrossHostRedirectDestination(t *testing.T) {
+	var dstRequests atomic.Int32
+	dst := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		dstRequests.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer dst.Close()
+
+	src := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, dst.URL, http.StatusFound)
+	}))
+	defer src.Close()
+	srcURL, err := url.Parse(src.URL)
+	if err != nil {
+		t.Fatalf("parsing source URL: %v", err)
+	}
+	srcURL.Host = "localhost:" + srcURL.Port()
+
+	target := config.TargetConfig{
+		URL:    srcURL.String(),
+		Type:   "http",
+		Weight: 1,
+		HTTP: config.HTTPConfig{
+			AllowCrossHostRedirects: true,
+			TimeoutS:                1,
+		},
+	}
+	cfg := baseCfg([]config.TargetConfig{target})
+	cfg.RateLimits = config.RateLimitsConfig{
+		DefaultRPS: 100,
+		PerDomain: []config.DomainRateLimit{
+			{Domain: hostname(dst.URL), RPS: 0.001},
+		},
+	}
+
+	eng, err := New(cfg, metrics.Noop())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Consume the destination host's burst token. The redirected request must
+	// wait on that host's limiter and should time out before reaching dst.
+	if err := eng.rl.Load().Wait(context.Background(), hostname(dst.URL)); err != nil {
+		t.Fatalf("pre-consuming destination limiter: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	results := make(chan task.Result, 1)
+	eng.SetObserver(func(result task.Result) {
+		results <- result
+	})
+
+	if err := eng.pool.Acquire(ctx, target.Type); err != nil {
+		t.Fatalf("pool.Acquire: %v", err)
+	}
+	eng.dispatch(ctx, task.Task{URL: target.URL, Type: target.Type, Config: target})
+
+	select {
+	case result := <-results:
+		if result.Error == nil {
+			t.Fatal("result.Error = nil, want redirect destination rate-limit wait error")
+		}
+	default:
+		t.Fatal("observer did not receive dispatch result")
+	}
+	if dstRequests.Load() != 0 {
+		t.Errorf("redirect destination received %d requests, want 0", dstRequests.Load())
 	}
 }
 


### PR DESCRIPTION
## Summary

Ensures opt-in cross-host HTTP redirects still pass through sendit's per-domain rate limiter before the redirected request is sent.

This builds on #240: cross-host redirects are blocked by default, but users can intentionally enable them with `http.allow_cross_host_redirects: true`. When they do, the redirected destination host now consumes its own per-domain rate-limit token before the HTTP client follows the redirect.

## Why

The engine rate-limits the original task host before dispatch. Redirects happen inside Go's `net/http` client, so an allowed redirect to another host could previously send traffic to the destination host without consulting that destination host's limiter.

## What changed

- Added a redirect-limiter hook to the HTTP driver.
- Wired the engine's active per-domain rate-limit registry into that hook.
- Added driver tests for allowed cross-host redirects, limiter host selection, and limiter-denied redirects.
- Added an engine regression test proving a redirected destination host is rate-limited before it receives traffic.
- Updated the README, docs site driver reference, and `[Unreleased]` changelog notes.

## Validation

```text
GOCACHE=/private/tmp/sendit-gocache GOMODCACHE=/private/tmp/sendit-gomodcache go test ./...
```

Passed locally.