### PR TITLE
fix: keep robots sitemaps on seed origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ under the affected version with a reference to the CVE or advisory.
 ### Security
 - Block HTTP redirects to a different host by default to avoid forwarding custom auth headers; set `http.allow_cross_host_redirects: true` to opt in to cross-host redirects.
 - Ensure opt-in cross-host HTTP redirects still pass through per-domain rate limiting before the redirected request is sent.
+- Keep `sendit generate --url` robots.txt sitemap discovery within the seed origin, including sitemap redirects.
 
 ### Changed
 - Bump `dorny/paths-filter` from 4.0.1 to 4.0.2 (CI: pinned SHA update)

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ The targets file format is `<url> <type> [weight]` per line — the same format 
 sendit generate --url https://example.com --depth 2 --max-pages 50 --output config/generated.yaml
 ```
 
-The crawler fetches the seed URL, parses `<a href>` links, and follows in-domain links breadth-first. `robots.txt` is respected by default; pass `--ignore-robots` to skip it.
+The crawler fetches the seed URL, parses `<a href>` links, and follows in-domain links breadth-first. `robots.txt` is respected by default; sitemap URLs and redirects discovered through robots.txt are only fetched when they stay on the seed origin. Pass `--ignore-robots` to skip robots.txt enforcement.
 
 ### From browser history
 

--- a/cmd/sendit/generate.go
+++ b/cmd/sendit/generate.go
@@ -196,9 +196,11 @@ func targetsFromCrawl(seedURL string, maxDepth, maxPages int, ignoreRobots bool)
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
+	client := newCrawlHTTPClient(base, 10*time.Second)
+
 	var disallowed, sitemaps []string
 	if !ignoreRobots {
-		disallowed, sitemaps = fetchRobotsInfo(ctx, base)
+		disallowed, sitemaps = fetchRobotsInfo(ctx, newCrawlHTTPClient(base, 5*time.Second), base)
 	}
 
 	type queueItem struct {
@@ -207,15 +209,20 @@ func targetsFromCrawl(seedURL string, maxDepth, maxPages int, ignoreRobots bool)
 		sitemap bool // true: parse as sitemap XML, not an HTML crawl target
 	}
 
-	client := &http.Client{Timeout: 10 * time.Second}
 	visited := map[string]bool{base.String(): true}
 	queue := []queueItem{{base.String(), 0, false}}
 
 	// Seed sitemaps discovered from robots.txt.
 	for _, s := range sitemaps {
-		if !visited[s] {
-			visited[s] = true
-			queue = append(queue, queueItem{s, 0, true})
+		u, err := url.Parse(s)
+		if err != nil || u.Scheme != base.Scheme || u.Host != base.Host {
+			continue
+		}
+		normalizeCrawlURL(u)
+		sitemapURL := u.String()
+		if !visited[sitemapURL] {
+			visited[sitemapURL] = true
+			queue = append(queue, queueItem{sitemapURL, 0, true})
 		}
 	}
 
@@ -275,6 +282,18 @@ func targetsFromCrawl(seedURL string, maxDepth, maxPages int, ignoreRobots bool)
 		}
 	}
 	return targets, nil
+}
+
+func newCrawlHTTPClient(base *url.URL, timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout: timeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if req.URL.Scheme != base.Scheme || req.URL.Host != base.Host {
+				return http.ErrUseLastResponse
+			}
+			return nil
+		},
+	}
 }
 
 // crawlPage fetches rawURL and returns in-domain links found on the page.
@@ -349,7 +368,7 @@ func normalizeCrawlURL(u *url.URL) {
 // fetchRobotsInfo downloads /robots.txt and returns the Disallow path prefixes
 // for the wildcard user-agent and any Sitemap: URLs declared in the file.
 // Returns nil slices on any error (fail open).
-func fetchRobotsInfo(ctx context.Context, base *url.URL) (disallowed, sitemaps []string) {
+func fetchRobotsInfo(ctx context.Context, client *http.Client, base *url.URL) (disallowed, sitemaps []string) {
 	robotsURL := &url.URL{Scheme: base.Scheme, Host: base.Host, Path: "/robots.txt"}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, robotsURL.String(), nil)
 	if err != nil {
@@ -357,7 +376,6 @@ func fetchRobotsInfo(ctx context.Context, base *url.URL) (disallowed, sitemaps [
 	}
 	req.Header.Set("User-Agent", generateUserAgent)
 
-	client := &http.Client{Timeout: 5 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil || resp.StatusCode != http.StatusOK {
 		return nil, nil

--- a/cmd/sendit/generate_test.go
+++ b/cmd/sendit/generate_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/lewta/sendit/internal/config"
@@ -1075,6 +1076,82 @@ func TestTargetsFromCrawl_SitemapViaRobots(t *testing.T) {
 	for u := range urls {
 		if strings.HasSuffix(u, ".xml") {
 			t.Errorf("sitemap XML file included as a target: %s", u)
+		}
+	}
+}
+
+func TestTargetsFromCrawl_RobotsCrossHostSitemapNotFetched(t *testing.T) {
+	var crossHostSitemapRequests atomic.Int32
+	crossHost := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		crossHostSitemapRequests.Add(1)
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(`<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">` +
+			"<url><loc>http://example.com/from-cross-host-sitemap</loc></url>" +
+			"</urlset>"))
+	}))
+	defer crossHost.Close()
+
+	seed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/robots.txt":
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write([]byte("User-agent: *\nDisallow:\nSitemap: " + crossHost.URL + "/sitemap.xml\n"))
+		default:
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte(`<html><body></body></html>`))
+		}
+	}))
+	defer seed.Close()
+
+	targets, err := targetsFromCrawl(seed.URL, 1, 50, false)
+	if err != nil {
+		t.Fatalf("targetsFromCrawl: %v", err)
+	}
+	if crossHostSitemapRequests.Load() != 0 {
+		t.Errorf("cross-host sitemap received %d requests, want 0", crossHostSitemapRequests.Load())
+	}
+	for _, tgt := range targets {
+		if strings.Contains(tgt.URL, "from-cross-host-sitemap") {
+			t.Errorf("cross-host sitemap URL included as target: %s", tgt.URL)
+		}
+	}
+}
+
+func TestTargetsFromCrawl_RobotsSitemapCrossHostRedirectNotFetched(t *testing.T) {
+	var crossHostSitemapRequests atomic.Int32
+	crossHost := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		crossHostSitemapRequests.Add(1)
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(`<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">` +
+			"<url><loc>http://example.com/from-redirected-sitemap</loc></url>" +
+			"</urlset>"))
+	}))
+	defer crossHost.Close()
+
+	seed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/robots.txt":
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write([]byte("User-agent: *\nDisallow:\nSitemap: http://" + r.Host + "/sitemap.xml\n")) //nolint:gosec // test handler; r.Host is always 127.0.0.1:<port>
+		case "/sitemap.xml":
+			http.Redirect(w, r, crossHost.URL+"/sitemap.xml", http.StatusFound)
+		default:
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte(`<html><body></body></html>`))
+		}
+	}))
+	defer seed.Close()
+
+	targets, err := targetsFromCrawl(seed.URL, 1, 50, false)
+	if err != nil {
+		t.Fatalf("targetsFromCrawl: %v", err)
+	}
+	if crossHostSitemapRequests.Load() != 0 {
+		t.Errorf("cross-host redirected sitemap received %d requests, want 0", crossHostSitemapRequests.Load())
+	}
+	for _, tgt := range targets {
+		if strings.Contains(tgt.URL, "from-redirected-sitemap") {
+			t.Errorf("cross-host redirected sitemap URL included as target: %s", tgt.URL)
 		}
 	}
 }

--- a/docs/content/docs/cli.md
+++ b/docs/content/docs/cli.md
@@ -67,6 +67,8 @@ sendit generate --url https://example.com --depth 2 --output config/generated.ya
 sendit generate --url https://example.com --ignore-robots --output config/generated.yaml
 ```
 
+When crawling from a seed URL, page links are kept in-domain. `robots.txt` is respected by default, and sitemap URLs or redirects discovered through robots.txt are only fetched when they remain on the seed origin.
+
 ### Generate from browser history / bookmarks
 
 ```sh


### PR DESCRIPTION
## Summary

Keeps `sendit generate --url` robots.txt sitemap discovery within the seed origin.

The crawler already filters page links to the seed origin, but robots.txt `Sitemap:` values were previously queued before an origin check. This meant a seed host could point `Sitemap:` at another host and cause sendit to fetch that sitemap document.

## What changed

- Added an origin-bound crawl HTTP client that refuses redirects away from the seed origin.
- Filters robots.txt sitemap URLs before queueing them for fetch.
- Preserves the existing same-origin sitemap behavior and the existing robots/page timeout split.
- Adds regressions for:
  - direct cross-host `Sitemap:` URLs not being fetched
  - same-origin sitemap URLs that redirect cross-host not being followed
  - existing same-origin sitemap discovery still working
- Updates the README, docs site CLI reference, and `[Unreleased]` changelog.

## Validation

```text
GOCACHE=/private/tmp/sendit-gocache GOMODCACHE=/private/tmp/sendit-gomodcache go test ./cmd/sendit -run 'TestTargetsFromCrawl_(SitemapViaRobots|RobotsCrossHostSitemapNotFetched|RobotsSitemapCrossHostRedirectNotFetched|SitemapSchemeNormalised)'
GOCACHE=/private/tmp/sendit-gocache GOMODCACHE=/private/tmp/sendit-gomodcache go test ./...
```

Both passed locally.