### PR TITLE
fix: bound generate crawl response parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ under the affected version with a reference to the CVE or advisory.
 - Block HTTP redirects to a different host by default to avoid forwarding custom auth headers; set `http.allow_cross_host_redirects: true` to opt in to cross-host redirects.
 - Ensure opt-in cross-host HTTP redirects still pass through per-domain rate limiting before the redirected request is sent.
 - Keep `sendit generate --url` robots.txt sitemap discovery within the seed origin, including sitemap redirects.
+- Bound `sendit generate --url` HTML and sitemap response parsing to prevent oversized crawl responses from exhausting local resources.
 
 ### Changed
 - Bump `dorny/paths-filter` from 4.0.1 to 4.0.2 (CI: pinned SHA update)

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ The targets file format is `<url> <type> [weight]` per line — the same format 
 sendit generate --url https://example.com --depth 2 --max-pages 50 --output config/generated.yaml
 ```
 
-The crawler fetches the seed URL, parses `<a href>` links, and follows in-domain links breadth-first. `robots.txt` is respected by default; sitemap URLs and redirects discovered through robots.txt are only fetched when they stay on the seed origin. Pass `--ignore-robots` to skip robots.txt enforcement.
+The crawler fetches the seed URL, parses `<a href>` links, and follows in-domain links breadth-first. `robots.txt` is respected by default; sitemap URLs and redirects discovered through robots.txt are only fetched when they stay on the seed origin. HTML pages larger than 5 MiB and sitemap XML larger than 1 MiB are skipped. Pass `--ignore-robots` to skip robots.txt enforcement.
 
 ### From browser history
 

--- a/cmd/sendit/generate.go
+++ b/cmd/sendit/generate.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -25,6 +26,11 @@ import (
 )
 
 const generateUserAgent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"
+
+const (
+	maxCrawlHTMLBytes    = 5 << 20
+	maxCrawlSitemapBytes = 1 << 20
+)
 
 // generateCmd returns the cobra command for 'sendit generate'.
 func generateCmd() *cobra.Command {
@@ -314,7 +320,12 @@ func crawlPage(ctx context.Context, client *http.Client, rawURL string, base *ur
 		return nil, nil // skip non-HTML responses
 	}
 
-	doc, err := html.Parse(resp.Body)
+	body, err := readLimitedResponseBody(resp.Body, maxCrawlHTMLBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	doc, err := html.Parse(bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -435,6 +446,11 @@ func fetchSitemapLocs(ctx context.Context, client *http.Client, sitemapURL strin
 		return nil, nil
 	}
 
+	body, err := readLimitedResponseBody(resp.Body, maxCrawlSitemapBytes)
+	if err != nil {
+		return nil, err
+	}
+
 	// Both <urlset><url><loc> and <sitemapindex><sitemap><loc> use <loc>.
 	type locEntry struct {
 		Loc string `xml:"loc"`
@@ -443,7 +459,7 @@ func fetchSitemapLocs(ctx context.Context, client *http.Client, sitemapURL strin
 		URLs     []locEntry `xml:"url"`
 		Sitemaps []locEntry `xml:"sitemap"`
 	}
-	if err := xml.NewDecoder(resp.Body).Decode(&doc); err != nil {
+	if err := xml.NewDecoder(bytes.NewReader(body)).Decode(&doc); err != nil {
 		return nil, err
 	}
 
@@ -459,6 +475,17 @@ func fetchSitemapLocs(ctx context.Context, client *http.Client, sitemapURL strin
 		}
 	}
 	return locs, nil
+}
+
+func readLimitedResponseBody(r io.Reader, maxBytes int64) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, fmt.Errorf("response body exceeds %d bytes", maxBytes)
+	}
+	return body, nil
 }
 
 // isHTMLURL returns true for URLs that are likely HTML pages. URLs with no

--- a/cmd/sendit/generate_test.go
+++ b/cmd/sendit/generate_test.go
@@ -1029,6 +1029,31 @@ func TestTargetsFromCrawl_FiltersNonHTML(t *testing.T) {
 	}
 }
 
+func TestTargetsFromCrawl_SkipsOversizedHTMLPage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/robots.txt" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html><body>" +
+			strings.Repeat(" ", maxCrawlHTMLBytes+1) +
+			`<a href="/after-limit">after limit</a>` +
+			"</body></html>"))
+	}))
+	defer srv.Close()
+
+	targets, err := targetsFromCrawl(srv.URL, 1, 50, true)
+	if err != nil {
+		t.Fatalf("targetsFromCrawl: %v", err)
+	}
+	for _, tgt := range targets {
+		if strings.HasSuffix(tgt.URL, "/after-limit") {
+			t.Errorf("oversized HTML page was parsed and discovered target: %s", tgt.URL)
+		}
+	}
+}
+
 // --- crawl: sitemap via robots.txt ---
 
 func TestTargetsFromCrawl_SitemapViaRobots(t *testing.T) {
@@ -1076,6 +1101,36 @@ func TestTargetsFromCrawl_SitemapViaRobots(t *testing.T) {
 	for u := range urls {
 		if strings.HasSuffix(u, ".xml") {
 			t.Errorf("sitemap XML file included as a target: %s", u)
+		}
+	}
+}
+
+func TestTargetsFromCrawl_SkipsOversizedSitemap(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/robots.txt":
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write([]byte("User-agent: *\nDisallow:\nSitemap: http://" + r.Host + "/sitemap.xml\n")) //nolint:gosec // test handler; r.Host is always 127.0.0.1:<port>
+		case "/sitemap.xml":
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write([]byte(`<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">` +
+				strings.Repeat(" ", maxCrawlSitemapBytes+1) +
+				"<url><loc>http://example.com/after-limit-sitemap</loc></url>" +
+				"</urlset>"))
+		default:
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte(`<html><body></body></html>`))
+		}
+	}))
+	defer srv.Close()
+
+	targets, err := targetsFromCrawl(srv.URL, 1, 50, false)
+	if err != nil {
+		t.Fatalf("targetsFromCrawl: %v", err)
+	}
+	for _, tgt := range targets {
+		if strings.HasSuffix(tgt.URL, "/after-limit-sitemap") {
+			t.Errorf("oversized sitemap was parsed and discovered target: %s", tgt.URL)
 		}
 	}
 }

--- a/docs/content/docs/cli.md
+++ b/docs/content/docs/cli.md
@@ -67,7 +67,7 @@ sendit generate --url https://example.com --depth 2 --output config/generated.ya
 sendit generate --url https://example.com --ignore-robots --output config/generated.yaml
 ```
 
-When crawling from a seed URL, page links are kept in-domain. `robots.txt` is respected by default, and sitemap URLs or redirects discovered through robots.txt are only fetched when they remain on the seed origin.
+When crawling from a seed URL, page links are kept in-domain. `robots.txt` is respected by default, and sitemap URLs or redirects discovered through robots.txt are only fetched when they remain on the seed origin. HTML pages larger than 5 MiB and sitemap XML larger than 1 MiB are skipped.
 
 ### Generate from browser history / bookmarks
 


### PR DESCRIPTION
## Summary

Bounds remote response parsing in `sendit generate --url` so maliciously large crawl responses cannot be fed directly into the HTML or sitemap XML parsers.

## Why

The crawler already limits crawl duration, depth, and page count, but `crawlPage` and `fetchSitemapLocs` parsed `resp.Body` directly. A crawled host could return an oversized HTML page or sitemap XML document within the timeout window and force local parser work/memory growth.

## What changed

- Adds fixed response body budgets before parsing:
  - HTML pages: 5 MiB
  - sitemap XML: 1 MiB
- Parses HTML and sitemap XML from bounded buffers instead of raw `resp.Body`.
- Skips oversized crawl responses as non-fatal crawl misses, preserving existing crawler behavior for unavailable/unparseable pages.
- Adds regressions where a link or sitemap URL appears only after the byte budget; the fixed crawler must not discover those targets.
- Updates `CHANGELOG.md`, README, and the docs site CLI page with the new limits.

## Validation

```text
GOCACHE=/private/tmp/sendit-gocache GOMODCACHE=/private/tmp/sendit-gomodcache go test ./cmd/sendit -run 'TestTargetsFromCrawl_(SkipsOversizedHTMLPage|SkipsOversizedSitemap|SitemapViaRobots|FiltersNonHTML)'
GOCACHE=/private/tmp/sendit-gocache GOMODCACHE=/private/tmp/sendit-gomodcache go test ./...
```

Both passed locally.