### PR TITLE
fix: bind metrics to loopback by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ under the affected version with a reference to the CVE or advisory.
 - Ensure opt-in cross-host HTTP redirects still pass through per-domain rate limiting before the redirected request is sent.
 - Keep `sendit generate --url` robots.txt sitemap discovery within the seed origin, including sitemap redirects.
 - Bound `sendit generate --url` HTML and sitemap response parsing to prevent oversized crawl responses from exhausting local resources.
+- Bind the optional Prometheus metrics endpoint to loopback by default; set `metrics.bind_address` explicitly to expose it.
 
 ### Changed
 - Bump `dorny/paths-filter` from 4.0.1 to 4.0.2 (CI: pinned SHA update)

--- a/README.md
+++ b/README.md
@@ -545,11 +545,14 @@ Mount your config at `/etc/sendit/config.yaml`. For container deployments, set:
 ```yaml
 metrics:
   enabled: true
+  bind_address: 0.0.0.0
   prometheus_port: 9090
 
 daemon:
   log_format: json   # friendlier for log aggregators
 ```
+
+Metrics bind to loopback by default because metric labels include target domains. Container deployments that publish the metrics port should explicitly set `bind_address: 0.0.0.0`.
 
 The `--foreground` flag is set in the image entrypoint — PID files are not useful inside containers.
 
@@ -848,8 +851,11 @@ Optional Prometheus exposition.
 ```yaml
 metrics:
   enabled: true
+  bind_address: 127.0.0.1
   prometheus_port: 9090     # GET http://localhost:9090/metrics
 ```
+
+Metrics bind to loopback by default because metric labels include target domains. Set `bind_address: 0.0.0.0` only when you intentionally expose `/metrics` to another host or container network.
 
 Exposed metrics:
 

--- a/cmd/sendit/generate.go
+++ b/cmd/sendit/generate.go
@@ -916,6 +916,7 @@ func formatConfig(w io.Writer, targets []config.TargetConfig) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "metrics:")
 	fmt.Fprintln(w, "  enabled: false")
+	fmt.Fprintln(w, "  bind_address: 127.0.0.1")
 	fmt.Fprintln(w, "  prometheus_port: 9090")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "daemon:")

--- a/cmd/sendit/generate_test.go
+++ b/cmd/sendit/generate_test.go
@@ -386,7 +386,7 @@ func TestFormatConfig_ContainsRequiredSections(t *testing.T) {
 	var b bytes.Buffer
 	formatConfig(&b, nil)
 	got := b.String()
-	for _, section := range []string{"pacing:", "limits:", "rate_limits:", "backoff:", "targets:", "metrics:", "daemon:"} {
+	for _, section := range []string{"pacing:", "limits:", "rate_limits:", "backoff:", "targets:", "metrics:", "bind_address:", "daemon:"} {
 		if !strings.Contains(got, section) {
 			t.Errorf("formatConfig output missing section %q", section)
 		}

--- a/cmd/sendit/main.go
+++ b/cmd/sendit/main.go
@@ -579,7 +579,7 @@ to pacing mode or resource limits (workers, cpu, memory) require a restart.`,
 			var m *metrics.Metrics
 			if cfg.Metrics.Enabled {
 				m = metrics.New()
-				go m.ServeHTTP(ctx, cfg.Metrics.PrometheusPort)
+				go m.ServeHTTP(ctx, cfg.Metrics.BindAddress, cfg.Metrics.PrometheusPort)
 			} else {
 				m = metrics.Noop()
 			}

--- a/config/burst.yaml
+++ b/config/burst.yaml
@@ -69,6 +69,7 @@ output:
 
 metrics:
   enabled: true
+  bind_address: "127.0.0.1"
   prometheus_port: 9090
 
 daemon:

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -160,6 +160,7 @@ targets:
 
 metrics:
   enabled: false
+  bind_address: "127.0.0.1"
   prometheus_port: 9090
 
 daemon:

--- a/docker/config.yaml
+++ b/docker/config.yaml
@@ -30,6 +30,7 @@ targets:
 
 metrics:
   enabled: true
+  bind_address: "0.0.0.0"  # required for Docker port publishing / Prometheus container scraping
   prometheus_port: 9090
 
 daemon:

--- a/docs/content/docs/configuration.md
+++ b/docs/content/docs/configuration.md
@@ -147,15 +147,18 @@ Optional Prometheus exposition endpoint.
 ```yaml
 metrics:
   enabled: true
+  bind_address: 127.0.0.1
   prometheus_port: 9090
 ```
 
-When enabled, two endpoints are served on `prometheus_port`:
+When enabled, two endpoints are served on `bind_address:prometheus_port`:
 
 | Endpoint | Description |
 |---|---|
 | `GET /metrics` | Prometheus scrape endpoint |
 | `GET /healthz` | Liveness probe — always returns `200 {"status":"ok"}` |
+
+Metrics bind to loopback by default. Set `bind_address: 0.0.0.0` only when you intentionally expose the endpoint to another host or container network.
 
 See [Metrics](../metrics/) for the full metric reference and label descriptions.
 

--- a/docs/content/docs/metrics.md
+++ b/docs/content/docs/metrics.md
@@ -12,8 +12,11 @@ sendit exposes a Prometheus scrape endpoint when `metrics.enabled` is `true`.
 ```yaml
 metrics:
   enabled: true
+  bind_address: 127.0.0.1
   prometheus_port: 9090
 ```
+
+The metrics listener binds to `127.0.0.1` by default because metric labels include target domains. Set `bind_address: 0.0.0.0` only when Prometheus runs on another host or container network that must scrape this process.
 
 Two endpoints are available on the configured port:
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("output.append", false)
 
 	v.SetDefault("metrics.enabled", false)
+	v.SetDefault("metrics.bind_address", "127.0.0.1")
 	v.SetDefault("metrics.prometheus_port", 9090)
 
 	v.SetDefault("daemon.pid_file", "/tmp/sendit.pid")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -123,6 +123,9 @@ targets:
 	if cfg.RateLimits.DefaultRPS != 0.5 {
 		t.Errorf("default default_rps = %v, want 0.5", cfg.RateLimits.DefaultRPS)
 	}
+	if cfg.Metrics.BindAddress != "127.0.0.1" {
+		t.Errorf("default metrics.bind_address = %q, want 127.0.0.1", cfg.Metrics.BindAddress)
+	}
 	if cfg.Backoff.InitialMs != 1000 {
 		t.Errorf("default backoff.initial_ms = %d, want 1000", cfg.Backoff.InitialMs)
 	}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -155,8 +155,9 @@ type OutputConfig struct {
 
 // MetricsConfig controls Prometheus metrics exposition.
 type MetricsConfig struct {
-	Enabled        bool `mapstructure:"enabled"`
-	PrometheusPort int  `mapstructure:"prometheus_port"`
+	Enabled        bool   `mapstructure:"enabled"`
+	BindAddress    string `mapstructure:"bind_address"`
+	PrometheusPort int    `mapstructure:"prometheus_port"`
 }
 
 // DaemonConfig holds daemon/process settings.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"time"
@@ -107,7 +108,7 @@ func domainOf(rawURL string) string {
 // Routes:
 //   - /metrics — Prometheus scrape endpoint
 //   - /healthz — liveness probe; always returns 200 {"status":"ok"}
-func (m *Metrics) ServeHTTP(ctx context.Context, port int) {
+func (m *Metrics) ServeHTTP(ctx context.Context, bindAddress string, port int) {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{}))
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
@@ -116,7 +117,7 @@ func (m *Metrics) ServeHTTP(ctx context.Context, port int) {
 	})
 
 	srv := &http.Server{
-		Addr:              fmt.Sprintf(":%d", port),
+		Addr:              listenAddr(bindAddress, port),
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
@@ -137,4 +138,11 @@ func (m *Metrics) ServeHTTP(ctx context.Context, port int) {
 	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		log.Error().Err(err).Msg("metrics server error")
 	}
+}
+
+func listenAddr(bindAddress string, port int) string {
+	if bindAddress == "" {
+		bindAddress = "127.0.0.1"
+	}
+	return net.JoinHostPort(bindAddress, fmt.Sprintf("%d", port))
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -146,7 +146,7 @@ func TestServeHTTP_HealthzRoute(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		m.ServeHTTP(ctx, port)
+		m.ServeHTTP(ctx, "127.0.0.1", port)
 	}()
 
 	var resp *http.Response
@@ -187,7 +187,7 @@ func TestServeHTTP_MetricsRoute(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		m.ServeHTTP(ctx, port)
+		m.ServeHTTP(ctx, "127.0.0.1", port)
 	}()
 
 	var resp *http.Response
@@ -210,6 +210,20 @@ func TestServeHTTP_MetricsRoute(t *testing.T) {
 
 	cancel()
 	<-done
+}
+
+func TestListenAddr_DefaultsToLoopback(t *testing.T) {
+	got := listenAddr("", 9090)
+	if got != "127.0.0.1:9090" {
+		t.Errorf("listenAddr empty bind = %q, want 127.0.0.1:9090", got)
+	}
+}
+
+func TestListenAddr_AllInterfacesWhenExplicit(t *testing.T) {
+	got := listenAddr("0.0.0.0", 9090)
+	if got != "0.0.0.0:9090" {
+		t.Errorf("listenAddr all interfaces = %q, want 0.0.0.0:9090", got)
+	}
 }
 
 // TestDomainOf verifies domain extraction from various URL formats.


### PR DESCRIPTION
## Summary

Binds the optional Prometheus metrics listener to loopback by default and adds an explicit `metrics.bind_address` setting for intentional exposure.

## Why

When metrics are enabled, `/metrics` includes target domains in Prometheus labels. The previous listener address `:%d` exposed those labels on all interfaces. Metrics are opt-in, but the endpoint is unauthenticated, so the safer default is loopback-only.

## What changed

- Adds `metrics.bind_address`, defaulting to `127.0.0.1`.
- Uses `bind_address:prometheus_port` when starting the metrics HTTP server.
- Keeps Docker/Prometheus container workflows working by setting `bind_address: "0.0.0.0"` in `docker/config.yaml`.
- Updates generated config, sample configs, README, docs site configuration and metrics pages, and `[Unreleased]` changelog.
- Adds tests for default loopback binding and explicit all-interface binding.

## Validation

```text
GOCACHE=/private/tmp/sendit-gocache GOMODCACHE=/private/tmp/sendit-gomodcache go test ./internal/metrics ./internal/config ./cmd/sendit
GOCACHE=/private/tmp/sendit-gocache GOMODCACHE=/private/tmp/sendit-gomodcache go test ./...
```

Both passed locally.