### PR TITLE
fix: keep scheduled pacing inside cron windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ under the affected version with a reference to the CVE or advisory.
 - Keep `sendit generate --url` robots.txt sitemap discovery within the seed origin, including sitemap redirects.
 - Bound `sendit generate --url` HTML and sitemap response parsing to prevent oversized crawl responses from exhausting local resources.
 - Bind the optional Prometheus metrics endpoint to loopback by default; set `metrics.bind_address` explicitly to expose it.
+- Keep scheduled pacing paused outside active cron windows instead of dispatching after each poll interval.
 
 ### Changed
 - Bump `dorny/paths-filter` from 4.0.1 to 4.0.2 (CI: pinned SHA update)

--- a/internal/engine/scheduler.go
+++ b/internal/engine/scheduler.go
@@ -33,11 +33,19 @@ type Scheduler struct {
 	// startedAt records when the scheduler was created. Used by burst mode
 	// to compute the linear ramp-up delay.
 	startedAt time.Time
+
+	// scheduledRecheckEvery controls how often scheduled mode rechecks whether a
+	// cron window has opened while dispatch is paused.
+	scheduledRecheckEvery time.Duration
 }
 
 // NewScheduler creates a Scheduler from the pacing config.
 func NewScheduler(cfg config.PacingConfig) *Scheduler {
-	s := &Scheduler{cfg: cfg, startedAt: time.Now()}
+	s := &Scheduler{
+		cfg:                   cfg,
+		startedAt:             time.Now(),
+		scheduledRecheckEvery: 5 * time.Second,
+	}
 
 	s.minDelayMs.Store(int64(cfg.MinDelayMs))
 	s.maxDelayMs.Store(int64(cfg.MaxDelayMs))
@@ -172,14 +180,11 @@ func (s *Scheduler) rateLimitedWait(ctx context.Context) error {
 }
 
 func (s *Scheduler) scheduledWait(ctx context.Context) error {
-	// If outside a cron window, block until context cancels.
-	if !s.inWindow.Load() {
+	for !s.inWindow.Load() {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(5 * time.Second):
-			// Re-check window state.
-			return nil
+		case <-time.After(s.scheduledRecheckEvery):
 		}
 	}
 	return s.rateLimitedWait(ctx)

--- a/internal/engine/scheduler_test.go
+++ b/internal/engine/scheduler_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/lewta/sendit/internal/config"
+	"golang.org/x/time/rate"
 )
 
 func humanCfg(minMs, maxMs int, jitter float64) config.PacingConfig {
@@ -133,18 +134,45 @@ func TestScheduler_Scheduled_OutsideWindow(t *testing.T) {
 		},
 	}
 	s := NewScheduler(cfg)
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	s.scheduledRecheckEvery = 10 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), 75*time.Millisecond)
 	defer cancel()
 
 	s.Start(ctx)
 
-	// Wait should return quickly (hits the 5s poll timer, but context expires first).
 	start := time.Now()
-	_ = s.Wait(ctx) // may return nil or ctx error depending on timing
+	err := s.Wait(ctx)
 	elapsed := time.Since(start)
 
-	if elapsed > 1*time.Second {
+	if err == nil {
+		t.Fatal("expected scheduled wait to block outside a window until context expires")
+	}
+	if elapsed < 50*time.Millisecond {
+		t.Errorf("Wait returned before context expiry while outside window: %v", elapsed)
+	}
+	if elapsed > 500*time.Millisecond {
 		t.Errorf("Wait in scheduled mode took too long: %v", elapsed)
+	}
+}
+
+// TestScheduler_Scheduled_InWindowDispatches verifies active scheduled windows
+// still use the rate limiter and permit dispatch.
+func TestScheduler_Scheduled_InWindowDispatches(t *testing.T) {
+	cfg := config.PacingConfig{
+		Mode:              "scheduled",
+		RequestsPerMinute: 60,
+	}
+	s := NewScheduler(cfg)
+	s.inWindow.Store(true)
+	s.limiter.Store(rate.NewLimiter(rate.Limit(10), 1))
+
+	ctx := context.Background()
+	start := time.Now()
+	if err := s.Wait(ctx); err != nil {
+		t.Fatalf("unexpected scheduled in-window wait error: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 250*time.Millisecond {
+		t.Errorf("scheduled in-window wait took too long: %v", elapsed)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes scheduled pacing so dispatch stays paused outside active cron windows. The scheduler now treats the outside-window poll timer as a recheck signal instead of returning success to the engine.

## Why

`Engine.Run` dispatches after `Scheduler.Wait` returns `nil`. In scheduled mode, the previous outside-window path waited 5 seconds and returned `nil`, which allowed one request to dispatch outside the configured cron window on each poll interval.

## What changed

- `scheduledWait` now loops while no cron window is active, returning only when the context is cancelled or an active window can pass through the rate limiter.
- Adds a test-time recheck interval so the outside-window behavior is covered without a 5-second test delay.
- Strengthens the outside-window test to require context cancellation rather than accepting `nil`.
- Adds an in-window scheduled pacing test to preserve intended dispatch behavior.
- Updates `[Unreleased]` changelog.

## Validation

```text
GOCACHE=/private/tmp/sendit-gocache GOMODCACHE=/private/tmp/sendit-gomodcache go test ./internal/engine
GOCACHE=/private/tmp/sendit-gocache GOMODCACHE=/private/tmp/sendit-gomodcache go test ./...
```

Both passed locally. The first run was repeated outside the sandbox because existing `httptest` coverage needs local listener sockets.