### PR TITLE
docs: prepare v1.2.5 patch release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ under the affected version with a reference to the CVE or advisory.
 
 ## [Unreleased]
 
+---
+
+## [1.2.5] - 2026-07-12
+
+Patch release for the security hardening changes from the July 2026 Codex Security scan.
+
 ### Security
 - Block HTTP redirects to a different host by default to avoid forwarding custom auth headers; set `http.allow_cross_host_redirects: true` to opt in to cross-host redirects.
 - Ensure opt-in cross-host HTTP redirects still pass through per-domain rate limiting before the redirected request is sent.
@@ -24,12 +30,6 @@ under the affected version with a reference to the CVE or advisory.
 - Bump `dorny/paths-filter` from 4.0.1 to 4.0.2 (CI: pinned SHA update)
 - Bump `google.golang.org/grpc` from 1.81.1 to 1.82.0 (routine minor release; transitive bump to `google.golang.org/genproto/googleapis/rpc`)
 - Bump `golangci/golangci-lint-action` from 9.2.1 to 9.3.0 (CI: linter tooling update)
-
----
-
-## [1.2.5] - 2026-07-01
-
-### Changed
 - Bump `actions/setup-go` from 6.4.0 to 6.5.0 (CI tooling update; used across all workflow files)
 - Bump `actions/attest-build-provenance` from 4.1.0 to 4.1.1 (CI/release: pinned SHA update for supply-chain integrity)
 - Bump `modernc.org/sqlite` from 1.52.0 to 1.53.0, with transitive bumps to `modernc.org/libc` (1.72.3 → 1.73.4), `cc/v4`, `ccgo/v4`, and `gc/v3` (routine upstream maintenance)
@@ -602,7 +602,9 @@ landed on v0.11.2 (out-of-sequence due to unblocking prerequisites).
 
 ---
 
-[Unreleased]: https://github.com/lewta/sendit/compare/v1.2.3...HEAD
+[Unreleased]: https://github.com/lewta/sendit/compare/v1.2.5...HEAD
+[1.2.5]: https://github.com/lewta/sendit/compare/v1.2.4...v1.2.5
+[1.2.4]: https://github.com/lewta/sendit/compare/v1.2.3...v1.2.4
 [1.2.3]: https://github.com/lewta/sendit/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/lewta/sendit/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/lewta/sendit/compare/v1.2.0...v1.2.1

--- a/README.md
+++ b/README.md
@@ -589,7 +589,7 @@ Controls how requests are spaced in time.
 
 - **`human`** — random delay per request uniformly sampled from `[min_delay_ms, max_delay_ms]`. `requests_per_minute` and `jitter_factor` are ignored in this mode.
 - **`rate_limited`** — token-bucket limiter at `requests_per_minute` plus a small random jitter after each token.
-- **`scheduled`** — cron expressions open active windows; within each window behaves like `rate_limited` at the window's own RPM. Dispatch is paused between windows.
+- **`scheduled`** — cron expressions open active windows; within each window behaves like `rate_limited` at the window's own RPM. Dispatch stays paused between windows; polling only checks whether a window has opened.
 - **`burst`** — fires requests as fast as worker slots allow with no inter-request delay. Intended for internal infrastructure testing. **Requires `--duration`** on `sendit start` — the engine refuses to run an unbounded burst session.
 
 ```yaml

--- a/docs/content/docs/configuration.md
+++ b/docs/content/docs/configuration.md
@@ -120,7 +120,7 @@ target_defaults:
 | `auth.type` | `""` | Auth type: `bearer` \| `basic` \| `header` \| `query` — see [Drivers](../drivers/#auth-block) |
 | `http.method` | `GET` | HTTP verb |
 | `http.timeout_s` | `15` | Request timeout (seconds) |
-| `http.allow_cross_host_redirects` | `false` | Follow redirects to a different host. Keep disabled when sending auth headers unless that forwarding is intended. |
+| `http.allow_cross_host_redirects` | `false` | Follow redirects to a different host. Redirected hosts still use per-domain rate limits. Keep disabled when sending auth headers unless that forwarding is intended. |
 | `browser.timeout_s` | `30` | Page load timeout (seconds) |
 | `dns.resolver` | `8.8.8.8:53` | DNS resolver address |
 | `dns.record_type` | `A` | DNS record type |

--- a/docs/content/docs/pacing.md
+++ b/docs/content/docs/pacing.md
@@ -34,7 +34,7 @@ At 30 RPM the dispatch loop fires roughly once every 2 seconds, plus a small jit
 
 ## `scheduled` mode
 
-Opens active windows defined by cron expressions. Within each window the mode behaves exactly like `rate_limited` at the window's own RPM. Between windows dispatch is paused (polling every 5 s).
+Opens active windows defined by cron expressions. Within each window the mode behaves exactly like `rate_limited` at the window's own RPM. Between windows dispatch stays paused; the scheduler polls every 5 s only to check whether a window has opened.
 
 ```yaml
 pacing:

--- a/docs/data/landing.yaml
+++ b/docs/data/landing.yaml
@@ -25,16 +25,16 @@ featureGrid:
   template: feature grid
 
   title: Key features
-  subtitle: sendit runs across all four major web protocols with configurable pacing and built-in courtesy limits so it never hammers targets or the local machine.
+  subtitle: sendit runs across HTTP, browser, DNS, WebSocket, and gRPC targets with configurable pacing and built-in courtesy limits so it never hammers targets or the local machine.
 
   items:
-    - title: Four driver types
+    - title: Five driver types
       icon: hub
-      description: Send real traffic over **HTTP/HTTPS**, headless **browser** (chromedp), **DNS** (miekg/dns), and **WebSocket** — all from one config file.
+      description: Send real traffic over **HTTP/HTTPS**, headless **browser** (chromedp), **DNS** (miekg/dns), **WebSocket**, and **gRPC** — all from one config file.
 
-    - title: Three pacing modes
+    - title: Four pacing modes
       icon: schedule
-      description: "**human** (random delay), **rate_limited** (token bucket), and **scheduled** (cron windows) — traffic that looks exactly like you want it to."
+      description: "**human** (random delay), **rate_limited** (token bucket), **scheduled** (cron windows), and **burst** (time-bounded internal load) — traffic that looks exactly like you want it to."
 
     - title: Polite by design
       icon: shield


### PR DESCRIPTION
## Summary

Prepares the documentation and changelog for a v1.2.5 patch release containing the merged July 2026 security hardening work. GitHub currently shows `v1.2.4` as the latest published release, so this PR uses `v1.2.5` as the next patch version.

## What changed

- Moves the current security hardening entries into `## [1.2.5] - 2026-07-12`.
- Folds the previously documented but unpublished `1.2.5` dependency updates into this same patch release.
- Updates changelog compare links so `1.2.5` compares from the published `v1.2.4` tag and `[Unreleased]` compares from `v1.2.5`.
- Clarifies scheduled pacing docs so polling between cron windows is described as a recheck only, not dispatch permission.
- Aligns the configuration reference with HTTP redirect/rate-limit behavior.
- Refreshes the docs landing page feature copy to include gRPC and burst mode.

## Validation

```text
gh release list --repo lewta/sendit --limit 10
git tag --list 'v1.2*' --sort=-version:refname
git diff --check
GOCACHE=/private/tmp/sendit-gocache GOMODCACHE=/private/tmp/sendit-gomodcache go run github.com/gohugoio/hugo@v0.147.1 mod verify
CGO_ENABLED=1 GOCACHE=/private/tmp/sendit-gocache GOMODCACHE=/private/tmp/sendit-gomodcache go run -tags extended github.com/gohugoio/hugo@v0.147.1 --minify --baseURL https://lewta.github.io/sendit/
GOCACHE=/private/tmp/sendit-gocache GOMODCACHE=/private/tmp/sendit-gomodcache go test ./...
```

All passed locally except `gh release list` was a verification command, not a pass/fail test; it confirmed the latest published release is `v1.2.4`. `hugo mod verify` reported the existing theme compatibility warnings, and the extended Hugo build completed successfully.