### PR TITLE
chore: prepare v1.6.0 release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -84,14 +84,14 @@ homebrew_casks:
       name: homebrew-tap
       token: "{{ .Env.GH_PAT }}"
     homepage: "https://github.com/lewta/sendit"
-    description: "Traffic generation tool for HTTP, DNS, WebSocket, and headless-browser targets."
+    description: "Traffic generation tool for HTTP, browser, DNS, WebSocket, gRPC, and SFTP targets."
     license: "MIT"
 
 nfpms:
   - package_name: sendit
     homepage: https://github.com/lewta/sendit
     maintainer: lewta <77890109+lewta@users.noreply.github.com>
-    description: Traffic generation tool for HTTP, DNS, WebSocket, and headless-browser targets.
+    description: Traffic generation tool for HTTP, browser, DNS, WebSocket, gRPC, and SFTP targets.
     license: MIT
     formats:
       - deb
@@ -119,13 +119,13 @@ scoops:
       name: scoop-bucket
       token: "{{ .Env.GH_PAT }}"
     homepage: https://github.com/lewta/sendit
-    description: Traffic generation tool for HTTP, DNS, WebSocket, and headless-browser targets.
+    description: Traffic generation tool for HTTP, browser, DNS, WebSocket, gRPC, and SFTP targets.
     license: MIT
 
 aurs:
   - name: sendit-bin
     homepage: "https://github.com/lewta/sendit"
-    description: "Traffic generation tool for HTTP, DNS, WebSocket, and headless-browser targets."
+    description: "Traffic generation tool for HTTP, browser, DNS, WebSocket, gRPC, and SFTP targets."
     maintainers:
       - "lewta <77890109+lewta@users.noreply.github.com>"
     license: MIT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ under the affected version with a reference to the CVE or advisory.
 
 ## [Unreleased]
 
+---
+
+## [1.6.0] - 2026-07-13
+
 ### Added
 - `type: sftp` driver with upload, download, and list operations, password or private-key authentication, configurable upload payload sizes, optional EICAR upload payloads, SSH algorithm allow-lists, connection reuse, and SFTP metadata in JSONL output.
 
@@ -605,7 +609,8 @@ landed on v0.11.2 (out-of-sequence due to unblocking prerequisites).
 
 ---
 
-[Unreleased]: https://github.com/lewta/sendit/compare/v1.2.5...HEAD
+[Unreleased]: https://github.com/lewta/sendit/compare/v1.6.0...HEAD
+[1.6.0]: https://github.com/lewta/sendit/compare/v1.2.5...v1.6.0
 [1.2.5]: https://github.com/lewta/sendit/compare/v1.2.4...v1.2.5
 [1.2.4]: https://github.com/lewta/sendit/compare/v1.2.3...v1.2.4
 [1.2.3]: https://github.com/lewta/sendit/compare/v1.2.2...v1.2.3


### PR DESCRIPTION
## Summary
- Move the SFTP driver changelog entry from `Unreleased` to `v1.6.0` dated 2026-07-13.
- Update changelog compare links for `v1.6.0`.
- Refresh GoReleaser package descriptions to include browser, gRPC, and SFTP targets.

## Testing
- `go test ./...`
- `git diff --check`

Release plan after merge:
- Tag the release-prep merge commit as `v1.6.0`.
- Push the tag to trigger the Release workflow / GoReleaser.

Issue #184 is already closed by PR #248.