### PR TITLE
docs: sync roadmap after v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ under the affected version with a reference to the CVE or advisory.
 
 ## [Unreleased]
 
+### Fixed
+- Sync roadmap and contributor-facing architecture notes with the completed auth and SFTP releases.
+
 ---
 
 ## [1.6.0] - 2026-07-13

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Backoff and per-domain rate-limit waits happen **inside** the goroutine so a slo
 | `internal/config` | Viper-backed YAML loader. `schema.go` defines all struct types. Validates on load; `targets_file` is parsed here too. |
 | `internal/task` | `Task`/`Result` types. `Selector` uses the Vose alias method for O(1) weighted random picks. |
 | `internal/ratelimit` | `Registry` — per-domain `x/time/rate` token buckets. `BackoffRegistry` — decorrelated jitter backoff (AWS-style); shared by all domains, keyed by hostname. `ClassifyError`/`ClassifyStatusCode` unify error handling across all driver types. |
-| `internal/driver` | `Driver` interface with five implementations: `http`, `browser` (chromedp), `dns` (miekg/dns), `websocket` (coder/websocket), `grpc` (google.golang.org/grpc + reflection). DNS RCODEs and gRPC status codes are mapped to HTTP-like status codes so the engine's error classifier works uniformly. |
+| `internal/driver` | `Driver` interface with six implementations: `http`, `browser` (chromedp), `dns` (miekg/dns), `websocket` (coder/websocket), `grpc` (google.golang.org/grpc + reflection), and `sftp` (pkg/sftp over x/crypto/ssh). DNS RCODEs, gRPC status codes, and SFTP outcomes are mapped to HTTP-like status codes so the engine's error classifier works uniformly. |
 | `internal/resource` | gopsutil CPU/RAM poller. `Admit()` blocks dispatch when either threshold is exceeded. |
 | `internal/metrics` | Prometheus counters/histograms. `Noop()` returns a no-op implementation when metrics are disabled — avoids nil checks everywhere. |
 | `internal/output` | JSONL/CSV result writer. A dedicated goroutine drains results non-blocking to the dispatch loop. |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,13 +42,13 @@ Features planned for future releases of sendit. Contributions are welcome — op
 - [v0.15.3 — Docs audit + fuzz CI fix ✓](#v0153--docs-audit--fuzz-ci-fix)
 - [v1.0.0 — TUI + stable API ✓](#v100--tui--stable-api)
 - [v1.1.0 — gRPC driver ✓](#v110--grpc-driver)
+- [v1.2.0 — Auth support ✓](#v120--auth-support-)
+- [v1.6.0 — SFTP driver ✓](#v160--sftp-driver-)
 
 **Planned**
-- [v1.2.0 — Auth support](#v120--auth-support)
-- [v1.3.0 — Request templating](#v130--request-templating)
-- [v1.4.0 — Replay command](#v140--replay-command)
-- [v1.5.0 — HTTP version control](#v150--http-version-control)
-- [v1.6.0 — SFTP driver ✓](#v160--sftp-driver-)
+- [Request templating](#future--request-templating)
+- [Replay command](#future--replay-command)
+- [HTTP version control](#future--http-version-control)
 
 **Research**
 - [Non-standard traffic driver](#research--non-standard-traffic-driver)
@@ -664,7 +664,7 @@ targets:
 
 ---
 
-## v1.2.0 — Auth support
+## v1.2.0 — Auth support ✓
 
 Per-target authentication so sendit can generate traffic against protected endpoints without manual header management.
 
@@ -674,7 +674,7 @@ Per-target authentication so sendit can generate traffic against protected endpo
 - `header`: arbitrary header name + value (covers API keys, `X-Api-Key`, etc.)
 - `query`: appends a key/value pair to the request URL query string
 - Auth config is redacted from `--dry-run` output and logs
-- Applies to `http`, `grpc`, and `websocket` drivers; ignored silently on `dns` and `browser`
+- Applies to `http` and `websocket` drivers; SFTP uses credentials from its own `sftp` block; other drivers ignore it
 
 ```yaml
 targets:
@@ -688,7 +688,7 @@ targets:
 
 ---
 
-## v1.3.0 — Request templating
+## Future — Request templating
 
 Variable substitution in target URLs and request bodies so a single target definition can generate varied traffic without duplicating config entries.
 
@@ -709,7 +709,7 @@ targets:
 
 ---
 
-## v1.4.0 — Replay command
+## Future — Replay command
 
 A `sendit replay` subcommand that reads a JSONL result file produced by `--output` and re-issues the same requests as live traffic — useful for reproducing a traffic pattern, debugging a failure sequence, or warming a cache.
 
@@ -727,7 +727,7 @@ sendit replay --input results.jsonl --filter status=5xx --rate 0.5
 
 ---
 
-## v1.5.0 — HTTP version control
+## Future — HTTP version control
 
 Explicit HTTP version selection for `http` targets. Today the driver uses Go's standard `http.Transport`, which automatically negotiates HTTP/2 over TLS via ALPN but provides no way to force or observe the negotiated protocol. HTTP/3 (QUIC) is not supported at all.
 

--- a/docs/content/docs/security.md
+++ b/docs/content/docs/security.md
@@ -16,7 +16,7 @@ sendit follows a rolling release model. Only the latest stable release receives 
 
 ## Latest security hardening release
 
-`v1.2.5` includes security hardening from the July 2026 Codex Security scan. The release keeps supported workflows intact while tightening several defaults:
+The latest stable release is `v1.6.0`. Security hardening from the July 2026 Codex Security scan shipped in `v1.2.5` and remains included in current releases. That hardening keeps supported workflows intact while tightening several defaults:
 
 - Cross-host HTTP redirects are blocked by default; set `http.allow_cross_host_redirects: true` only when cross-host redirects are intentional.
 - Opt-in cross-host redirects still pass through per-domain rate limiting before the redirected request is sent.


### PR DESCRIPTION
## Summary
- move completed auth and SFTP work into the completed roadmap bucket
- make remaining roadmap candidates version-neutral now that v1.6.0 has shipped
- refresh contributor/security docs to mention the SFTP driver and current latest stable release

## Validation
- git diff --check
- Hugo build not run locally: hugo is not installed in this environment; Docs workflow installs Hugo in CI