### PR TITLE
docs: remove retired Go Report Card badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ under the affected version with a reference to the CVE or advisory.
 
 ### Fixed
 - Sync roadmap and contributor-facing architecture notes with the completed auth and SFTP releases.
+- Remove the retired Go Report Card badge from the README.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![CI](https://img.shields.io/github/actions/workflow/status/lewta/sendit/ci.yml?branch=main&label=tests)](https://github.com/lewta/sendit/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/lewta/sendit)](https://github.com/lewta/sendit/releases/latest)
 [![Go version](https://img.shields.io/badge/go-1.24+-00ADD8?logo=go&logoColor=white)](https://go.dev)
-[![Go Report Card](https://goreportcard.com/badge/github.com/lewta/sendit)](https://goreportcard.com/report/github.com/lewta/sendit)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/lewta/sendit/badge)](https://securityscorecards.dev/viewer/?uri=github.com/lewta/sendit)
 [![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/12213/badge)](https://bestpractices.coreinfrastructure.org/projects/12213)
 [![codecov](https://codecov.io/gh/lewta/sendit/graph/badge.svg)](https://codecov.io/gh/lewta/sendit)


### PR DESCRIPTION
## Summary
- remove the Go Report Card badge from the README
- add an Unreleased changelog note for the badge removal

## Why
Go Report Card has been sunset: the upstream repository was archived on July 1, 2026 and the service notice said the live site would be shut down after that date. The README already has current quality signals from CI, OpenSSF Scorecard, OpenSSF Best Practices, and Codecov.

## Validation
- git diff --check