### PR TITLE
chore: release v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+
+## [1.6.1] - 2026-08-01
 ### Changed
 - Bumped google.golang.org/grpc from 1.82.0 to 1.82.1 (semver-patch) for bug fixes and security updates
 - Bumped modernc.org/sqlite from 1.54.0 to 1.55.0 (semver-minor) for upstream bug fixes


### PR DESCRIPTION
Automated release changelog update for v1.6.1 (dependabot #267 merge).