### PR TITLE
chore: release v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+
+## [1.6.2] - 2026-08-08
 ### Changed
 - Bumped google.golang.org/grpc from 1.82.0 to 1.82.1 (semver-patch) for bug fixes and security updates
 - Bumped modernc.org/sqlite from 1.54.0 to 1.55.0 (semver-minor) for upstream bug fixes


### PR DESCRIPTION
Patch release bundling dependency bumps merged from PRs #269-#273 (grpc, sqlite, godog, codeql-action, dorny/paths-filter). Tag v1.6.2 to be pushed after merge to trigger goreleaser.