### PR TITLE
chore: release v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+
+## [1.6.1] - 2026-08-08
 ### Changed
 - Aligned local development, documentation, and the pinned Docker builder on Go 1.26.5; added canonical Make targets, tool-neutral contributor guidance, and reproducible CI tool versions.
 - Split the Cobra CLI implementation into focused command files without changing command behavior.


### PR DESCRIPTION
## Summary

- cut the accumulated Unreleased changes as `v1.6.1`
- include the dependency updates, developer scaffolding improvements, and CLI file split
- preserve an empty Unreleased section for subsequent work

## Validation

- `git diff --check`
- `go test ./...`