### PR TITLE
ci: add AUR release recovery workflow

### DIFF
--- a/.github/workflows/release-aur.yml
+++ b/.github/workflows/release-aur.yml
@@ -1,0 +1,40 @@
+name: Recover AUR
+
+# Publishes an existing GitHub release to AUR without attempting to recreate
+# or modify the immutable GitHub release. Use this after a release succeeds on
+# GitHub but AUR publication fails independently.
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to publish to AUR (e.g. v1.6.1)"
+        required: true
+
+permissions: read-all
+
+jobs:
+  publish-aur:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: refs/tags/${{ inputs.tag }}
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Publish existing release to AUR
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7
+        with:
+          version: "~> v2"
+          args: release --clean --skip=homebrew,scoop,notarize
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GORELEASER_CURRENT_TAG: ${{ inputs.tag }}
+          SKIP_GH_RELEASE: "true"
+          AUR_SSH_KEY: ${{ secrets.AUR_SSH_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Changed
+- Added a manual AUR-only recovery workflow for releases whose GitHub artifacts are already published and immutable.
+
 ## [1.6.1] - 2026-08-08
 ### Changed
 - Aligned local development, documentation, and the pinned Docker builder on Go 1.26.5; added canonical Make targets, tool-neutral contributor guidance, and reproducible CI tool versions.


### PR DESCRIPTION
## Summary

Add a manual AUR-only recovery workflow for releases whose GitHub artifacts were already published before AUR failed.

The workflow checks out an existing tag, rebuilds the configured artifacts, skips Homebrew, Scoop, macOS notarization, and GitHub release uploads, then publishes only the AUR package using the existing scoped secret.

## Root cause

The original v1.6.1 release published all GitHub assets successfully, then failed because AUR was down for maintenance. Rerunning the normal release workflow cannot recover it because GitHub releases are immutable and reject duplicate asset uploads.

## Impact

Maintainers can recover AUR independently without modifying an immutable GitHub release or rerunning the Homebrew and Scoop publishers.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-aur.yml")'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release-aur.yml`
- `git diff --check`
- `make verify`
- GoReleaser 2.17.1 configuration validation and snapshot release completed successfully during release audit

The existing manual tap recovery was separately run for v1.6.1 and completed successfully.