### PR TITLE
ci: avoid GitHub mutation during AUR recovery

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -131,18 +131,18 @@ aurs:
     license: MIT
     private_key: "{{ .Env.AUR_SSH_KEY }}"
     git_url: "ssh://aur@aur.archlinux.org/sendit-bin.git"
+    url_template: "https://github.com/lewta/sendit/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     package: |-
       install -Dm755 "./sendit" "${pkgdir}/usr/bin/sendit"
       install -Dm644 "./completions/sendit.bash" "${pkgdir}/usr/share/bash-completion/completions/sendit"
       install -Dm644 "./completions/sendit.zsh" "${pkgdir}/usr/share/zsh/site-functions/_sendit"
       install -Dm644 "./completions/sendit.fish" "${pkgdir}/usr/share/fish/vendor_completions.d/sendit.fish"
 
-# SKIP_GH_RELEASE=true skips artifact uploads and keeps the existing release
-# unchanged. Used by release-taps.yml: GoReleaser reads the existing release
-# to compute download URLs for the homebrew cask and scoop manifest, then
-# pushes those to the tap/bucket repos — without touching the release itself.
+# SKIP_GH_RELEASE=true disables only the SCM release publisher so recovery
+# workflows can publish to other destinations without touching an existing
+# immutable GitHub release.
 release:
-  skip_upload: '{{ if eq .Env.SKIP_GH_RELEASE "true" }}true{{ else }}false{{ end }}'
+  disable: '{{ if eq .Env.SKIP_GH_RELEASE "true" }}true{{ else }}false{{ end }}'
   mode: keep-existing
 
 checksum:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Changed
 - Added a manual AUR-only recovery workflow for releases whose GitHub artifacts are already published and immutable.
+- Prevented AUR recovery from attempting to modify an existing immutable GitHub release.
 
 ## [1.6.1] - 2026-08-08
 ### Changed


### PR DESCRIPTION
## Summary

- disable only GoReleaser's SCM release publisher when `SKIP_GH_RELEASE=true`
- give the AUR publisher an explicit immutable GitHub release download URL
- document the recovery correction in the changelog

## Root cause

The first AUR recovery run generated the AUR metadata, then GoReleaser attempted to PATCH the existing GitHub release. The workflow's read-only token correctly rejected that mutation with HTTP 403.

## Impact

The manual AUR recovery workflow can publish an existing tag to AUR without recreating or modifying its immutable GitHub release. Normal release runs are unchanged because they do not set `SKIP_GH_RELEASE`.

## Verification

- GoReleaser v2.17.1 configuration check
- recovery-mode GoReleaser snapshot with SCM release disabled and AUR metadata generated
- `make verify`
- `git diff --check`