### PR TITLE
ci: load AUR recovery config from main

### DIFF
--- a/.github/workflows/release-aur.yml
+++ b/.github/workflows/release-aur.yml
@@ -28,11 +28,16 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Load recovery configuration from main
+        run: |
+          git fetch --no-tags origin main --depth=1
+          git show FETCH_HEAD:.goreleaser.yaml > "${RUNNER_TEMP}/goreleaser.yaml"
+
       - name: Publish existing release to AUR
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7
         with:
           version: "~> v2"
-          args: release --clean --skip=homebrew,scoop,notarize
+          args: release --config ${{ runner.temp }}/goreleaser.yaml --clean --skip=homebrew,scoop,notarize
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GORELEASER_CURRENT_TAG: ${{ inputs.tag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Changed
 - Added a manual AUR-only recovery workflow for releases whose GitHub artifacts are already published and immutable.
 - Prevented AUR recovery from attempting to modify an existing immutable GitHub release.
+- Made AUR recovery use the current recovery configuration while building the selected release tag.
 
 ## [1.6.1] - 2026-08-08
 ### Changed


### PR DESCRIPTION
## Summary

- keep building the selected immutable release tag
- load the current reviewed recovery configuration from `main`
- pass that configuration explicitly to GoReleaser

## Root cause

The recovery workflow checks out the selected tag. That correctly preserves the released source, but it also selects the old GoReleaser configuration embedded in that tag, so later recovery fixes merged to `main` are never used.

## Impact

AUR recovery builds the exact tagged source while using the current recovery-safe publishing configuration. The immutable tag and GitHub release remain unchanged.

## Verification

- Actionlint
- YAML parsing
- `git diff --check`
- `make verify`