### PR TITLE
chore: release v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [1.6.2] - 2026-08-19
+
 ### Changed
 - Upgraded Go to 1.26.6 and aligned the golang.org/x module-tooling dependency chain around x/mod 0.40.0 to fix transparency-log verification vulnerabilities GO-2026-6179 and GO-2026-6180.
 - Added a manual AUR-only recovery workflow for releases whose GitHub artifacts are already published and immutable.


### PR DESCRIPTION
Patch release bundling dependency bumps merged from PR #282 (protobuf 1.36.11→1.36.12) and PR #283 (actions/attest-build-provenance 4.1.1→4.2.2). Tag v1.6.2 to be pushed after merge to trigger goreleaser.

Note: main branch protection requires PR + status checks, so this release commit could not be pushed directly per the runbook. Please review/merge; I'll push the v1.6.2 tag immediately after.