### PR TITLE
chore: release v1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [1.6.3] - 2026-08-22
+
 ### Changed
 - Bumped github.com/miekg/dns from 1.1.72 to 1.1.73 (semver-patch) for upstream bug fixes
 - Bumped github/codeql-action group (init/autobuild/analyze/upload-sarif) from v4.37.6 to v4.37.7 for upstream fixes


### PR DESCRIPTION
Cuts patch release v1.6.3 after merging dependabot PRs #286 and #287. Updates CHANGELOG to move Unreleased entries into the 1.6.3 section.